### PR TITLE
use double underscore as internal nesting separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 ===
 
 ## master
+
+- change nesting separator from `_` to `__` and use it consistently (also in sorting fields)
+
+## 0.8.0
 - rename gem (dry-request_handler --> request_handler)
 - remove env based config for logger
 

--- a/Guardfile
+++ b/Guardfile
@@ -17,7 +17,7 @@
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
 
 group :red_green_refactor, halt_on_fail: true do
-  guard :rspec, cmd: 'bundle exec rspec' do
+  guard :rspec, cmd: 'bundle exec rspec', all_after_pass: true do
     require 'guard/rspec/dsl'
     dsl = Guard::RSpec::Dsl.new(self)
 

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -126,7 +126,7 @@ module RequestHandler
     def params
       raise MissingArgumentError, params: 'is missing' if request.params.nil?
       raise ExternalArgumentError, params: 'must be a Hash' unless request.params.is_a?(Hash)
-      @params ||= Helper.deep_transform_keys_in_object(request.params) { |k| k.tr('.', '_') }
+      @params ||= Helper.deep_transform_keys_in_object(request.params) { |k| k.gsub('.', '__') }
     end
 
     def config

--- a/lib/request_handler/include_option_handler.rb
+++ b/lib/request_handler/include_option_handler.rb
@@ -17,7 +17,7 @@ module RequestHandler
         rescue Dry::Types::ConstraintError
           raise OptionNotAllowedError, option.to_sym => 'is not an allowed include option'
         end
-        option.to_sym
+        option.gsub('.', '__').to_sym
       end
     end
 

--- a/lib/request_handler/sort_option_handler.rb
+++ b/lib/request_handler/sort_option_handler.rb
@@ -20,6 +20,7 @@ module RequestHandler
       options.map do |option|
         name, order = parse_option(option)
         allowed_option(name)
+        name.gsub!('.', '__')
         SortOption.new(name, order)
       end
     end

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'fuubar', '~> 2.2'
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "codecov"
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'codecov'
 
   spec.add_development_dependency 'rubocop_runner', '~> 2.0'
   spec.add_development_dependency 'rubocop', '~> 0.46.0'

--- a/spec/integration/request_handler_spec.rb
+++ b/spec/integration/request_handler_spec.rb
@@ -12,7 +12,7 @@ class IntegrationTestRequestHandler < RequestHandler::Base
         max_size 50
       end
 
-      posts_samples_photos do
+      posts__samples__photos do
         default_size 3
       end
 
@@ -31,10 +31,10 @@ class IntegrationTestRequestHandler < RequestHandler::Base
       schema(Dry::Validation.Form do
                required(:user_id).filled(:int?)
                required(:name).filled(:str?)
-               optional(:age_gt).filled(:int?)
-               optional(:age_gte).filled(:int?)
-               optional(:posts_awesome).filled(:bool?)
-               optional(:posts_samples_photos_has_thumbnail).filled(:bool?)
+               optional(:age__gt).filled(:int?)
+               optional(:age__gte).filled(:int?)
+               optional(:posts__awesome).filled(:bool?)
+               optional(:posts__samples__photos__has_thumbnail).filled(:bool?)
              end)
       additional_url_filter %i(user_id)
     end
@@ -214,20 +214,20 @@ describe RequestHandler do
 
       expect(dto.filter).to eq(user_id:                            234,
                                name:                               'foo',
-                               posts_awesome:                      true,
-                               age_gt:                             5,
-                               posts_samples_photos_has_thumbnail: false)
+                               posts__awesome:                      true,
+                               age__gt:                             5,
+                               posts__samples__photos__has_thumbnail: false)
 
-      expect(dto.page).to eq(posts_size:                  34,
-                             posts_number:                2,
+      expect(dto.page).to eq(posts__size:                  34,
+                             posts__number:                2,
                              number:                      3,
                              size:                        15,
-                             users_size:                  40,
-                             users_number:                1,
-                             posts_samples_photos_size:   4,
-                             posts_samples_photos_number: 1,
-                             assets_size:                 10,
-                             assets_number:               1)
+                             users__size:                  40,
+                             users__number:                1,
+                             posts__samples__photos__size:   4,
+                             posts__samples__photos__number: 1,
+                             assets__size:                 10,
+                             assets__number:               1)
 
       expect(dto.include).to eq(%i(user groups))
 

--- a/spec/request_handler/base_spec.rb
+++ b/spec/request_handler/base_spec.rb
@@ -317,14 +317,18 @@ describe RequestHandler::Base do
                                         {
                                           'foo.bar'      => 'test',
                                           'nested'       => { 'nested.foo.bar' => 'test2' },
-                                          'nested.twice' => { 'nested.twice.foo.bar' => { 'nested.again' => 'test3' } }
+                                          'nested.twice' => {
+                                            'nested.twice.foo.bar_underscored' => {
+                                              'nested.again' => 'test3'
+                                            }
+                                          }
                                         },
                                 env:    {},
                                 body:   StringIO.new('body'))
       expect(testclass.new(request: request).send(:params))
-        .to eq('foo_bar'      => 'test',
-               'nested'       => { 'nested_foo_bar' => 'test2' },
-               'nested_twice' => { 'nested_twice_foo_bar' => { 'nested_again' => 'test3' } })
+        .to eq('foo__bar' => 'test',
+               'nested' => { 'nested__foo__bar' => 'test2' },
+               'nested__twice' => { 'nested__twice__foo__bar_underscored' => { 'nested__again' => 'test3' } })
     end
   end
 

--- a/spec/request_handler/include_option_handler_spec.rb
+++ b/spec/request_handler/include_option_handler_spec.rb
@@ -2,23 +2,31 @@
 require 'spec_helper'
 require 'request_handler/include_option_handler'
 describe RequestHandler::IncludeOptionHandler do
+  let(:handler) do
+    options_type = Dry::Types['strict.string'].enum('user', 'email', 'user.posts')
+    described_class.new(params:               params,
+                        allowed_options_type: options_type)
+  end
   shared_examples 'proccesses valid options correctly' do
     it 'it returns an array of include options' do
-      handler = described_class.new(params:               params,
-                                    allowed_options_type: Dry::Types['strict.string'].enum('user', 'email'))
       expect(handler.run).to eq output
     end
   end
   shared_examples 'proccesses invalid options correctly' do
     it 'raises an error if the include options are invalid' do
-      handler = described_class.new(params:               params,
-                                    allowed_options_type: Dry::Types['strict.string'].enum('user', 'email'))
       expect { handler.run }.to raise_error(error)
     end
   end
+
   context 'option is allowed' do
     let(:params) { { 'include' => 'user,email' } }
     let(:output) { [:user, :email] }
+    it_behaves_like 'proccesses valid options correctly'
+  end
+
+  context 'nested attributes are correctly transformed' do
+    let(:params) { { 'include' => 'user,user.posts' } }
+    let(:output) { [:user, :user__posts] }
     it_behaves_like 'proccesses valid options correctly'
   end
 
@@ -37,20 +45,12 @@ describe RequestHandler::IncludeOptionHandler do
 
   context 'options contain a space' do
     let(:params) { { 'include' => 'user, email' } }
-    let(:handler) do
-      described_class.new(params:               params,
-                          allowed_options_type: Dry::Types['strict.string'].enum('user', 'email'))
-    end
     let(:error) { RequestHandler::ExternalArgumentError }
     it_behaves_like 'proccesses invalid options correctly'
   end
 
   context 'option is not allowed' do
     let(:params)  { { 'include' => 'user,password' } }
-    let(:handler) do
-      described_class.new(params:               params,
-                          allowed_options_type: Dry::Types['strict.string'].enum('user', 'email'))
-    end
     let(:error) { RequestHandler::OptionNotAllowedError }
     it_behaves_like 'proccesses invalid options correctly'
   end

--- a/spec/request_handler/page_handler_spec.rb
+++ b/spec/request_handler/page_handler_spec.rb
@@ -45,10 +45,10 @@ describe RequestHandler::PageHandler do
       let(:params) do
         {
           'page' => {
-            'posts_size'   => '34',
-            'posts_number' => '2',
-            'users_size'   => '25',
-            'users_number' => '2'
+            'posts__size'   => '34',
+            'posts__number' => '2',
+            'users__size'   => '25',
+            'users__number' => '2'
           }
         }
       end
@@ -56,10 +56,10 @@ describe RequestHandler::PageHandler do
         {
           number:       1,
           size:         15,
-          posts_number: 2,
-          posts_size:   34,
-          users_number: 2,
-          users_size:   25
+          posts__number: 2,
+          posts__size:   34,
+          users__number: 2,
+          users__size:   25
         }
       end
       it_behaves_like 'valid input'
@@ -69,10 +69,10 @@ describe RequestHandler::PageHandler do
       let(:params) do
         {
           'page' => {
-            'posts_size'   => '34',
-            'posts_number' => '2',
-            'users_size'   => '100',
-            'users_number' => '2'
+            'posts__size'   => '34',
+            'posts__number' => '2',
+            'users__size'   => '100',
+            'users__number' => '2'
           }
         }
       end
@@ -80,10 +80,10 @@ describe RequestHandler::PageHandler do
         {
           number:       1,
           size:         15,
-          posts_number: 2,
-          posts_size:   34,
-          users_number: 2,
-          users_size:   40
+          posts__number: 2,
+          posts__size:   34,
+          users__number: 2,
+          users__size:   40
         }
       end
       it_behaves_like 'valid input'
@@ -93,17 +93,17 @@ describe RequestHandler::PageHandler do
     context 'size not defined in the params' do
       let(:params) do
         { 'page' => {
-          'users_size'   => '39',
-          'users_number' => '2'
+          'users__size'   => '39',
+          'users__number' => '2'
         } }
       end
       let(:output) do
         { number:       1,
           size:         15,
-          posts_number: 1,
-          posts_size:   30,
-          users_number: 2,
-          users_size:   39 }
+          posts__number: 1,
+          posts__size:   30,
+          users__number: 2,
+          users__size:   39 }
       end
       it_behaves_like 'valid input'
     end
@@ -112,8 +112,8 @@ describe RequestHandler::PageHandler do
       let(:error) { RequestHandler::ExternalArgumentError }
       let(:params) do
         { 'page' => {
-          'users_size'   => '40',
-          'users_number' => 'asdf'
+          'users__size'   => '40',
+          'users__number' => 'asdf'
         } }
       end
       it_behaves_like 'input that causes an error'
@@ -123,8 +123,8 @@ describe RequestHandler::PageHandler do
       let(:error) { RequestHandler::ExternalArgumentError }
       let(:params) do
         { 'page' => {
-          'users_size'   => '40',
-          'users_number' => '-20'
+          'users__size'   => '40',
+          'users__number' => '-20'
         } }
       end
       it_behaves_like 'input that causes an error'
@@ -134,8 +134,8 @@ describe RequestHandler::PageHandler do
       let(:error) { RequestHandler::ExternalArgumentError }
       let(:params) do
         { 'page' => {
-          'users_size'   => '-40',
-          'users_number' => '20'
+          'users__size'   => '-40',
+          'users__number' => '20'
         } }
       end
       it_behaves_like 'input that causes an error'
@@ -145,8 +145,8 @@ describe RequestHandler::PageHandler do
       let(:error) { RequestHandler::ExternalArgumentError }
       let(:params) do
         { 'page' => {
-          'users_size'   => 'asdf',
-          'users_number' => '2'
+          'users__size'   => 'asdf',
+          'users__number' => '2'
         } }
       end
       it_behaves_like 'input that causes an error'
@@ -170,8 +170,8 @@ describe RequestHandler::PageHandler do
         'page' => {
           'size'         => '20',
           'number'       => '2',
-          'posts_size'   => '500',
-          'posts_number' => '2'
+          'posts__size'   => '500',
+          'posts__number' => '2'
         }
       }
     end
@@ -240,8 +240,8 @@ describe RequestHandler::PageHandler do
       let(:params) do
         {
           'page' => {
-            'posts_size'   => '500',
-            'posts_number' => '2'
+            'posts__size'   => '500',
+            'posts__number' => '2'
           }
         }
       end
@@ -249,8 +249,8 @@ describe RequestHandler::PageHandler do
         {
           number:       1,
           size:         15,
-          posts_number: 2,
-          posts_size:   500
+          posts__number: 2,
+          posts__size:   500
         }
       end
       let(:warning) { 'posts max_size config not set' }
@@ -262,7 +262,7 @@ describe RequestHandler::PageHandler do
       let(:params) do
         {
           'page' => {
-            'foo_size' => '3'
+            'foo__size' => '3'
           }
         }
       end
@@ -270,11 +270,11 @@ describe RequestHandler::PageHandler do
         {
           number:       1,
           size:         15,
-          posts_number: 1,
-          posts_size:   30
+          posts__number: 1,
+          posts__size:   30
         }
       end
-      let(:warning) { 'client sent unknown option ["foo_size"]' }
+      let(:warning) { 'client sent unknown option ["foo.size"]' }
       it_behaves_like 'input that causes a warning'
     end
   end

--- a/spec/request_handler/sort_option_handler_spec.rb
+++ b/spec/request_handler/sort_option_handler_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 require 'request_handler/sort_option_handler'
 describe RequestHandler::SortOptionHandler do
   let(:handler) do
-    described_class.new(params: params, allowed_options_type: Dry::Types['strict.string'].enum('id', 'date'))
+    options_type = Dry::Types['strict.string'].enum('id', 'date', 'posts.created_at')
+    described_class.new(params: params,
+                        allowed_options_type: options_type)
   end
   shared_examples 'processes valid sort options correctly' do
     it 'returns the right sort options' do
@@ -33,6 +35,14 @@ describe RequestHandler::SortOptionHandler do
     let(:output) do
       [RequestHandler::SortOption.new('id', :asc),
        RequestHandler::SortOption.new('date', :desc)]
+    end
+    it_behaves_like 'processes valid sort options correctly'
+  end
+
+  context 'nested attributes as sort options are correctly transformed' do
+    let(:params) { { 'sort' => 'posts.created_at' } }
+    let(:output) do
+      [RequestHandler::SortOption.new('posts__created_at', :asc)]
     end
     it_behaves_like 'processes valid sort options correctly'
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ if ENV['TRAVIS']
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 SimpleCov.start do
-  add_filter "/spec/"
+  add_filter '/spec/'
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)


### PR DESCRIPTION
this also fixes an inconsistency re. the sort option field names