### PR TITLE
Parse `included` array from request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## master
 
 - Parse `included` array from request body
+- Body no longer accepts a default
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- Parse `included` array from request body
+
 ## 0.10.0
 
 - raise an error if mandatory options are missing in the handler configuration

--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ class DemoHandler < RequestHandler::Base
       options(->(_handler, _request) { { foo: "bar" } })
       # options({foo: "bar"}) # also works for hash options instead of procs
     end
+  end
 
-    def to_dto
-      OpenStruct.new(
-        body:    body_params,
-        page:    page_params,
-        include: include_params,
-        filter:  filter_params,
-        sort:    sort_params,
-        headers: headers
-      )
-    end
+  def to_dto
+    OpenStruct.new(
+      body:    body_params,
+      page:    page_params,
+      include: include_params,
+      filter:  filter_params,
+      sort:    sort_params,
+      headers: headers
+    )
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,132 @@ include_options = [:posts__comments]
 sort_options = SortOption.new(:posts__published_on, :asc)
 ```
 
+### Included relations
+
+Sometimes you want to create a single resource with its relations in a single
+request, ensuring that everything or nothing at all is created.  However, the
+current JSON API specification does not mention anything about how to achieve
+this at all, it is expected that all associated resources already exist.  
+`request_handler` attempts to solve this problem by allowing the request body
+to contain an `included` array with all the resources that have to be created.
+
+#### Example
+
+With this request handler:
+
+```ruby
+class CreateQuestionHandler < RequestHandler::Base
+  options do
+    body do
+      schema(
+        Dry::Validation.JSON do
+          required(:id).filled(:str?)
+          required(:type).filled(:str?)
+          required(:content).filled(:str?)
+
+          optional(:media).schema do
+            required(:id).filled(:str?)
+            required(:type).filled(:str?)
+          end
+        end
+      )
+
+      included do
+        media(
+          Dry::Validation.JSON do
+            required(:id).filled(:str?)
+            required(:type).filled(:str?)
+            required(:url).filled(:str?)
+
+            optional(:categories).schema do
+              required(:id).filled(:str?)
+              required(:type).filled(:str?)
+            end
+          end
+        )
+      end
+    end
+  end
+
+  def to_dto
+    # see the resulting body_params below
+    { body: body_params }
+  end
+end
+```
+
+The following JSON object including its included items is validated with the
+defined schema:
+
+``` json
+{
+  "data": {
+    "id": "1",
+    "type": "questions",
+    "attributes": {
+      "content": "How much is the fish?"
+    },
+    "relationships": {
+      "media": {
+          "data": {
+            "id": "image-123456",
+            "type": "media"
+          }
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "image-123456",
+      "type": "media",
+      "attributes": {
+        "url": "https://example.com/fish.jpg"
+      },
+      "relationships": {
+        "categories": {
+          "data": {
+            "id": "123",
+            "type": "categories"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+The resulting `body_params` will be this:
+
+``` ruby
+[
+  # The first object is the main resource object, i.e. the one that is about to
+  # be created
+  {
+    id:      '1',
+    type:    'questions',
+    content: 'How much is the fish?'
+    media:   [
+      {
+        id:   'image-123456',
+        type: 'media'
+      }
+    ]
+  },
+  # The remaining objects are every included object, validated with the schema
+  # defined above
+  {
+    id:         'image-123456',
+    type:       'media',
+    url:        'https://example.com/fish.jpg',
+    categories: {
+      id:   '123',
+      type: 'categories'
+    }
+  }
+]
+```
+
 ### Configuration
 
 The default logger and separator can be changed globally by using

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -95,15 +95,12 @@ module RequestHandler
     end
 
     def parse_body_params
-      defaults = fetch_defaults('body.defaults', {})
-      parsed_body = BodyParser.new(
+      BodyParser.new(
         request:          request,
         schema:           lookup!('body.schema'),
         schema_options:   execute_options(lookup('body.options')),
         included_schemas: lookup('body.included')
       ).run
-      return defaults.merge(parsed_body) unless parsed_body.is_a? Array
-      parsed_body.unshift(defaults.merge(parsed_body.shift))
     end
 
     def parse_fieldsets_params

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -96,11 +96,14 @@ module RequestHandler
 
     def parse_body_params
       defaults = fetch_defaults('body.defaults', {})
-      defaults.merge(BodyParser.new(
-        request:        request,
-        schema:         lookup!('body.schema'),
-        schema_options: execute_options(lookup('body.options'))
-      ).run)
+      parsed_body = BodyParser.new(
+        request:          request,
+        schema:           lookup!('body.schema'),
+        schema_options:   execute_options(lookup('body.options')),
+        included_schemas: lookup('body.included')
+      ).run
+      return defaults.merge(parsed_body) unless parsed_body.is_a? Array
+      parsed_body.unshift(defaults.merge(parsed_body.shift))
     end
 
     def parse_fieldsets_params

--- a/lib/request_handler/schema_parser.rb
+++ b/lib/request_handler/schema_parser.rb
@@ -16,16 +16,16 @@ module RequestHandler
 
     def validate_schema(data, with: schema)
       raise MissingArgumentError, data: 'is missing' if data.nil?
-      validator = validate(data, with: with)
+      validator = validate(data, schema: with)
       validation_failure?(validator)
       validator.output
     end
 
-    def validate(data, with:)
+    def validate(data, schema:)
       if schema_options.empty?
-        with.call(data)
+        schema.call(data)
       else
-        with.with(schema_options).call(data)
+        schema.with(schema_options).call(data)
       end
     end
 

--- a/lib/request_handler/schema_parser.rb
+++ b/lib/request_handler/schema_parser.rb
@@ -14,18 +14,18 @@ module RequestHandler
 
     private
 
-    def validate_schema(data)
+    def validate_schema(data, with: schema)
       raise MissingArgumentError, data: 'is missing' if data.nil?
-      validator = validate(data)
+      validator = validate(data, with: with)
       validation_failure?(validator)
       validator.output
     end
 
-    def validate(data)
+    def validate(data, with:)
       if schema_options.empty?
-        schema.call(data)
+        with.call(data)
       else
-        schema.with(schema_options).call(data)
+        with.with(schema_options).call(data)
       end
     end
 

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -79,10 +79,10 @@ describe RequestHandler do
           expect(testhandler.to_dto).to eq(OpenStruct.new(body: { name: 'About naming stuff and cache invalidation' }))
         end
 
-        it 'works for valid data with includes' do
+        it 'raises a SchemaValidationError with valid data and includes' do
           request = build_mock_request(params: {}, headers: {}, body: valid_body_with_included)
           testhandler = testclass.new(request: request)
-          expect(testhandler.to_dto).to eq(OpenStruct.new(body: { name: 'About naming stuff and cache invalidation' }))
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::SchemaValidationError)
         end
       end
       context 'valid schema with included objects' do

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -10,6 +10,17 @@ describe RequestHandler do
             "attributes": {
               "name": "About naming stuff and cache invalidation"
             }
+          }
+        }
+        JSON
+      end
+      let(:valid_body_with_included) do
+        <<-JSON
+        {
+          "data": {
+            "attributes": {
+              "name": "About naming stuff and cache invalidation"
+            }
           },
           "included": [
             {
@@ -64,6 +75,12 @@ describe RequestHandler do
 
         it 'works for valid data' do
           request = build_mock_request(params: {}, headers: {}, body: valid_body)
+          testhandler = testclass.new(request: request)
+          expect(testhandler.to_dto).to eq(OpenStruct.new(body: { name: 'About naming stuff and cache invalidation' }))
+        end
+
+        it 'works for valid data with includes' do
+          request = build_mock_request(params: {}, headers: {}, body: valid_body_with_included)
           testhandler = testclass.new(request: request)
           expect(testhandler.to_dto).to eq(OpenStruct.new(body: { name: 'About naming stuff and cache invalidation' }))
         end
@@ -122,11 +139,18 @@ describe RequestHandler do
           expect { testhandler.to_dto }.to raise_error(RequestHandler::MissingArgumentError)
         end
 
-        it 'works for valid data' do
-          request = build_mock_request(params: {}, headers: {}, body: valid_body)
+        it 'works for valid data with includes' do
+          request = build_mock_request(params: {}, headers: {}, body: valid_body_with_included)
           testhandler = testclass.new(request: request)
           expect(testhandler.to_dto)
             .to eq(OpenStruct.new(body: [{ name: 'About naming stuff and cache invalidation' }, { view_count: 1337 }]))
+        end
+
+        it 'works for valid data without includes' do
+          request = build_mock_request(params: {}, headers: {}, body: valid_body)
+          testhandler = testclass.new(request: request)
+          expect(testhandler.to_dto)
+            .to eq(OpenStruct.new(body: [{ name: 'About naming stuff and cache invalidation' }]))
         end
       end
       context 'invalid schema' do

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -10,7 +10,15 @@ describe RequestHandler do
             "attributes": {
               "name": "About naming stuff and cache invalidation"
             }
-          }
+          },
+          "included": [
+            {
+              "type": "my_types",
+              "attributes": {
+                "view_count": 1337
+              }
+            }
+          ]
         }
         JSON
       end
@@ -58,6 +66,67 @@ describe RequestHandler do
           request = build_mock_request(params: {}, headers: {}, body: valid_body)
           testhandler = testclass.new(request: request)
           expect(testhandler.to_dto).to eq(OpenStruct.new(body: { name: 'About naming stuff and cache invalidation' }))
+        end
+      end
+      context 'valid schema with included objects' do
+        let(:invalid_body) do
+          <<-JSON
+          {
+            "data": {
+              "attributes": {
+                "name": "About naming stuff and cache invalidation"
+              }
+            },
+            "included": [
+              {
+                "type": "my_types",
+                "attributes": {
+                  "some_random_number": 1337
+                }
+              }
+            ]
+          }
+        JSON
+        end
+        let(:testclass) do
+          Class.new(RequestHandler::Base) do
+            options do
+              body do
+                schema(Dry::Validation.JSON do
+                         required(:name).filled(:str?)
+                       end)
+
+                included do
+                  my_types(Dry::Validation.JSON do
+                             required(:view_count).filled(:int?)
+                           end)
+                end
+              end
+            end
+            def to_dto
+              OpenStruct.new(
+                body:  body_params
+              )
+            end
+          end
+        end
+        it 'raises a SchemaValidationError with invalid data in included type' do
+          request = build_mock_request(params: {}, headers: {}, body: invalid_body)
+          testhandler = testclass.new(request: request)
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::SchemaValidationError)
+        end
+
+        it 'raises a MissingArgumentError with missing data' do
+          request = instance_double('Rack::Request', params: {}, env: {}, body: nil)
+          testhandler = testclass.new(request: request)
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::MissingArgumentError)
+        end
+
+        it 'works for valid data' do
+          request = build_mock_request(params: {}, headers: {}, body: valid_body)
+          testhandler = testclass.new(request: request)
+          expect(testhandler.to_dto)
+            .to eq(OpenStruct.new(body: [{ name: 'About naming stuff and cache invalidation' }, { view_count: 1337 }]))
         end
       end
       context 'invalid schema' do

--- a/spec/request_handler/base_spec.rb
+++ b/spec/request_handler/base_spec.rb
@@ -269,9 +269,10 @@ describe RequestHandler::Base do
     end
     let(:expected_args) do
       {
-        request:        request,
-        schema:         'schema',
-        schema_options: tested_options[:output]
+        request:          request,
+        schema:           'schema',
+        schema_options:   tested_options[:output],
+        included_schemas: nil
       }
     end
     let(:tested_method) { :body_params }

--- a/spec/request_handler/base_spec.rb
+++ b/spec/request_handler/base_spec.rb
@@ -256,13 +256,11 @@ describe RequestHandler::Base do
   context '#body_params' do
     let(:testclass) do
       opts = tested_options[:input]
-      defs = tested_defaults[:input]
       Class.new(RequestHandler::Base) do
         options do
           body do
             schema 'schema'
             options(opts)
-            defaults(defs)
           end
         end
       end
@@ -277,7 +275,6 @@ describe RequestHandler::Base do
     end
     let(:tested_method) { :body_params }
     let(:tested_parser) { RequestHandler::BodyParser }
-    let(:tested_defaults) { { input: nil, output: runstub.run } }
     context 'with a proc as options' do
       let(:tested_options) do
         { input:  ->(_parser, _request) { { body_user_id: 1 } },
@@ -285,7 +282,6 @@ describe RequestHandler::Base do
       end
       it_behaves_like 'correct_persistence'
       it_behaves_like 'correct_arguments_passed'
-      it_behaves_like 'correct_default_handling_hash'
     end
     context 'with a proc using the request as options' do
       let(:tested_options) do
@@ -294,19 +290,16 @@ describe RequestHandler::Base do
       end
       it_behaves_like 'correct_persistence'
       it_behaves_like 'correct_arguments_passed'
-      it_behaves_like 'correct_default_handling_hash'
     end
     context 'with a hash as options' do
       let(:tested_options) { { input: { body_user_id: 1 }, output: { body_user_id: 1 } } }
       it_behaves_like 'correct_persistence'
       it_behaves_like 'correct_arguments_passed'
-      it_behaves_like 'correct_default_handling_hash'
     end
     context 'with nil as options' do
       let(:tested_options) { { input: nil, output: {} } }
       it_behaves_like 'correct_persistence'
       it_behaves_like 'correct_arguments_passed'
-      it_behaves_like 'correct_default_handling_hash'
     end
   end
 

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -381,7 +381,9 @@ describe RequestHandler::BodyParser do
     end
     it 'flattens the body as expected' do
       expect(handler).to receive(:validate_schema).with(wanted_result.shift)
-      wanted_result.each { |result| expect(handler).to receive(:validate_schema).with(result, with: anything) }
+      wanted_result.each do |result|
+        expect(handler).to receive(:validate_schema).with(result, with: anything)
+      end
       handler.run
     end
   end

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -11,12 +11,7 @@ describe RequestHandler::BodyParser do
   end
   shared_examples 'flattens the body as expected' do
     it 'returns the flattened body' do
-      if wanted_result.is_a? Array
-        expect(handler).to receive(:validate_schema).with(wanted_result.shift)
-        wanted_result.each { |result| expect(handler).to receive(:validate_schema).with(result, with: anything) }
-      else
-        expect(handler).to receive(:validate_schema).with(wanted_result)
-      end
+      expect(handler).to receive(:validate_schema).with(wanted_result)
       handler.run
     end
   end
@@ -384,7 +379,11 @@ describe RequestHandler::BodyParser do
         }
       ]
     end
-    it_behaves_like 'flattens the body as expected'
+    it 'flattens the body as expected' do
+      expect(handler).to receive(:validate_schema).with(wanted_result.shift)
+      wanted_result.each { |result| expect(handler).to receive(:validate_schema).with(result, with: anything) }
+      handler.run
+    end
   end
 
   it 'fails if the request body is nil' do


### PR DESCRIPTION
This is a possible solution for #10.

It extends the body options with an `included` block, where you can set the schema for each type.

A simplified example for the definition:

``` ruby
options do
  body do
    # Schema definition for the main resource
    schema(Dry::Validation.JSON { ... })

    included do
      # Schema definition for `media' type
      media(Dry::Validation.JSON { ... })
      # Schema definition for `other_types' type
      other_types(Dry::Validation.JSON { ... })
    end
  end
end
```

The resulting `body_params` then becomes an array if the `included` block was given with a few definitions.  This array contains the main resource as the first element.