### PR TITLE
extended fieldset config to allow passing all fields for a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog
 - update rubocop and fix danger check
 - drop support for ruby 2.1 (dry-types does not support it anymore either which makes supporting it here pointless)
 
+## 0.12.0
+- enhanced request_handler by now allowing an enum, "true" and "false" as validation criterias 
+
 ## 0.11.0
 
 - Parse `included` array from request body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ Changelog
 
 - update rubocop and fix danger check
 - drop support for ruby 2.1 (dry-types does not support it anymore either which makes supporting it here pointless)
-
-## 0.12.0
-- enhanced request_handler by now allowing an enum, "true" and "false" as validation criterias 
+- adapt fieldset validation to allow all fields in addition to a specific enum
 
 ## 0.11.0
 

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -28,16 +28,15 @@ module RequestHandler
 
     private
 
-
     def parse_options(type, values)
-      return [] if allowed[type] === false
+      return [] if allowed[type] == false
       values.split(',').map! do |option|
         parse_option(type, option)
       end
     end
 
     def parse_option(type, option)
-      if allowed[type] === true
+      if allowed[type] == true
         option.to_sym
       else
         allowed[type].call(option).to_sym

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -6,7 +6,7 @@ module RequestHandler
   class FieldsetsParser
     def initialize(params:, allowed: {}, required: [])
       @params = params
-      allowed = allowed.reject { |k, v| v.is_a?(FalseClass) }
+      allowed.reject! { |k, v| v == false }
       allowed.each_value do |option|
         raise InternalArgumentError, allowed: 'must be a Enum or a Boolean' unless
               option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass) || option.is_a?(FalseClass)

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -6,6 +6,7 @@ module RequestHandler
   class FieldsetsParser
     def initialize(params:, allowed: {}, required: [])
       @params = params
+      allowed = allowed.reject { |k, v| v.is_a?(FalseClass) }
       allowed.each_value do |option|
         raise InternalArgumentError, allowed: 'must be a Enum or a Boolean' unless
               option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass) || option.is_a?(FalseClass)

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -11,7 +11,7 @@ module RequestHandler
               option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass) || option.is_a?(FalseClass)
       end
       @allowed = allowed
-      raise InternalArgumentError, allowed: 'must be an Array' unless required.is_a?(Array)
+      raise InternalArgumentError, required: 'must be an Array' unless required.is_a?(Array)
       @required = required
     end
 
@@ -29,7 +29,7 @@ module RequestHandler
     private
 
     def parse_options(type, values)
-      return [] if allowed[type] == false
+      raise ExternalArgumentError, fieldsets: "invalid type: <#{type}>" if allowed[type] == false
       values.split(',').map! do |option|
         parse_option(type, option)
       end

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -6,7 +6,8 @@ module RequestHandler
     def initialize(params:, allowed: {}, required: [])
       @params = params
       allowed.each_value do |option|
-        raise InternalArgumentError, allowed: 'must be a Enum' unless option.is_a?(Dry::Types::Enum)
+        raise InternalArgumentError, allowed: 'must be a Enum or a Boolean' unless
+              option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass) || option.is_a?(FalseClass)
       end
       @allowed = allowed
       raise InternalArgumentError, allowed: 'must be an Array' unless required.is_a?(Array)
@@ -16,7 +17,6 @@ module RequestHandler
     def run
       fields = params['fields']
       raise_missing_fields_param unless fields
-
       fieldsets = fields.to_h.each_with_object({}) do |(type, values), memo|
         type = type.to_sym
         raise_invalid_field_option(type)
@@ -27,14 +27,20 @@ module RequestHandler
 
     private
 
+
     def parse_options(type, values)
+      return [] if allowed[type] === false
       values.split(',').map! do |option|
         parse_option(type, option)
       end
     end
 
     def parse_option(type, option)
-      allowed[type].call(option).to_sym
+      if allowed[type] === true
+        option.to_sym
+      else
+        allowed[type].call(option).to_sym
+      end
     rescue Dry::Types::ConstraintError
       raise ExternalArgumentError, fieldsets: "invalid field: <#{option}> for type: #{type}"
     end

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -6,7 +6,7 @@ module RequestHandler
   class FieldsetsParser
     def initialize(params:, allowed: {}, required: [])
       @params = params
-      allowed.reject! { |k, v| v == false }
+      allowed.reject! { |_k, v| v == false }
       allowed.each_value do |option|
         raise InternalArgumentError, allowed: 'must be a Enum or a Boolean' unless
               option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass)

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -9,7 +9,7 @@ module RequestHandler
       allowed.reject! { |k, v| v == false }
       allowed.each_value do |option|
         raise InternalArgumentError, allowed: 'must be a Enum or a Boolean' unless
-              option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass) || option.is_a?(FalseClass)
+              option.is_a?(Dry::Types::Enum) || option.is_a?(TrueClass)
       end
       @allowed = allowed
       raise InternalArgumentError, required: 'must be an Array' unless required.is_a?(Array)
@@ -30,7 +30,6 @@ module RequestHandler
     private
 
     def parse_options(type, values)
-      raise ExternalArgumentError, fieldsets: "invalid type: <#{type}>" if allowed[type] == false
       values.split(',').map! do |option|
         parse_option(type, option)
       end

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -8,8 +8,8 @@ describe RequestHandler::FieldsetsParser do
         allowed do
           posts Dry::Types['strict.string'].enum('awesome', 'samples')
           photos Dry::Types['strict.string'].enum('foo', 'bar')
-          sample true
-          run_session false
+          videos true
+          musicfiles false
         end
         required [:posts]
       end
@@ -74,30 +74,34 @@ describe RequestHandler::FieldsetsParser do
         let(:expected) { { posts: [:awesome], photos: [:foo] } }
       end
     end
-  end
-
-  context 'fieldset types tests' do
-    context 'valid fieldset wich return all parameters because fieldset is set to true in RequestHandler config' do
-      it_behaves_like 'returns fieldsets' do
-        let(:params) { { 'fields' => { 'posts' => 'awesome', 'sample' => 'hello,moin,gutentach' } } }
-        let(:expected) { { posts: [:awesome], sample: %i[hello moin gutentach] } }
-      end
-    end
 
     context 'invalid fieldset wich fails because of unrecognized field in posts' do
       it_behaves_like 'fails' do
         let(:params) { { 'fields' => { 'posts' => 'awesome,good' } } }
       end
     end
+  end
 
-    context 'invalid fieldset which fails because fieldset "run_session" is set to false in RequestHandler config' do
+  context 'fieldset types tests' do
+    context 'valid fieldset wich return all parameters because fieldset is set to true in RequestHandler config' do
+      it_behaves_like 'returns fieldsets' do
+        let(:params) { { 'fields' => { 'posts' => 'awesome', 'videos' => 'nr1,nr2,nr3' } } }
+        let(:expected) { { posts: [:awesome], videos: %i[nr1 nr2 nr3] } }
+      end
+    end
+
+    context 'invalid fieldset wich fails because of unrecognized field in posts' do
+      it_behaves_like 'fails' do
+        let(:params) { { 'fields' => { 'posts' => 'post1,post2', 'videos' => 'nr1,nr2' } } }
+      end
+    end
+
+    context 'invalid fieldset which fails because fieldset "musicfiles" is set to false in RequestHandler config' do
       it_behaves_like 'fails' do
         let(:params) do
-          { 'fields' => { 'posts' => 'awesome',
-                          'run_session' => 'hello,moin,gutentach',
-                          'sample'      => 'hello,moin,gutentach' } }
+          { 'fields' => { 'videos' => 'video1,video2,video3',
+                          'musicfiles' => 'nr1,nr2' } }
         end
-        let(:expected) { { posts: [:awesome], sample: %i[hello moin gutentach], run_session: [] } }
       end
     end
   end

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -25,6 +25,7 @@ describe RequestHandler::FieldsetsParser do
         .to eq(expected)
     end
   end
+
   shared_examples 'fails' do
     let(:error) { RequestHandler::ExternalArgumentError }
     it 'raises an error' do
@@ -36,6 +37,7 @@ describe RequestHandler::FieldsetsParser do
         .to raise_error(error)
     end
   end
+
   context 'fieldset tests' do
     context 'no fieldset settings in the config or request' do
       it_behaves_like 'returns fieldsets' do
@@ -44,6 +46,7 @@ describe RequestHandler::FieldsetsParser do
         let(:params) { {} }
       end
     end
+
     context 'fieldset settings and the parameter are set' do
       it_behaves_like 'returns fieldsets' do
         let(:params) { { 'fields' => { 'posts' => 'awesome' } } }
@@ -102,6 +105,16 @@ describe RequestHandler::FieldsetsParser do
           { 'fields' => { 'videos' => 'video1,video2,video3',
                           'musicfiles' => 'nr1,nr2' } }
         end
+        let(:error) { RequestHandler::OptionNotAllowedError }
+      end
+    end
+    context 'invalid fieldset which fails because fieldset "games" is not set in RequestHandler config' do
+      it_behaves_like 'fails' do
+        let(:params) do
+          { 'fields' => { 'videos' => 'video1,video2,video3',
+                          'games' => 'nr1,nr2' } }
+        end
+        let(:error) { RequestHandler::OptionNotAllowedError }
       end
     end
   end

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -86,12 +86,12 @@ describe RequestHandler::FieldsetsParser do
 
     context 'invalid fieldset wich fails because of unrecognized field in posts' do
       it_behaves_like 'fails' do
-        let(:params) { { 'fields' => { 'posts' => 'awesome,good', 'sample' => 'hello,moin' } } }
+        let(:params) { { 'fields' => { 'posts' => 'awesome,good' } } }
       end
     end
 
-    context 'valid fieldset wich return no parameters because fieldset is set to false in RequestHandler config' do
-      it_behaves_like 'returns fieldsets' do
+    context 'invalid fieldset which fails because fieldset "run_session" is set to false in RequestHandler config' do
+      it_behaves_like 'fails' do
         let(:params) do
           { 'fields' => { 'posts' => 'awesome',
                           'run_session' => 'hello,moin,gutentach',

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -54,7 +54,7 @@ describe RequestHandler::FieldsetsParser do
     context 'fieldset settings and multiple parameters are set' do
       it_behaves_like 'returns fieldsets' do
         let(:params)  { { 'fields' => { 'posts' => 'awesome,samples' } } }
-        let(:expected) { { posts: [:awesome, :samples] } }
+        let(:expected) { { posts: %i[awesome samples] } }
       end
     end
 
@@ -67,7 +67,7 @@ describe RequestHandler::FieldsetsParser do
 
     context 'fieldset settings and the required parameters are set' do
       before do
-        opts.required = [:posts, :photos]
+        opts.required = %i[posts photos]
       end
       it_behaves_like 'returns fieldsets' do
         let(:params) { { 'fields' => { 'posts' => 'awesome', 'photos' => 'foo' } } }
@@ -80,7 +80,7 @@ describe RequestHandler::FieldsetsParser do
     context 'valid fieldset wich return all parameters because fieldset is set to true in RequestHandler config' do
       it_behaves_like 'returns fieldsets' do
         let(:params) { { 'fields' => { 'posts' => 'awesome', 'sample' => 'hello,moin,gutentach' } } }
-        let(:expected) { { posts: [:awesome], sample: [:hello, :moin, :gutentach] } }
+        let(:expected) { { posts: [:awesome], sample: %i[hello moin gutentach] } }
       end
     end
 
@@ -92,10 +92,12 @@ describe RequestHandler::FieldsetsParser do
 
     context 'valid fieldset wich return no parameters because fieldset is set to false in RequestHandler config' do
       it_behaves_like 'returns fieldsets' do
-        let(:params) { { 'fields' => { 'posts'       => 'awesome',
-                                       'run_session' => 'hello,moin,gutentach',
-                                       'sample'      => 'hello,moin,gutentach' } } }
-        let(:expected) { { posts: [:awesome], sample: [:hello, :moin, :gutentach] , run_session: [] } }
+        let(:params) do
+          { 'fields' => { 'posts' => 'awesome',
+                          'run_session' => 'hello,moin,gutentach',
+                          'sample'      => 'hello,moin,gutentach' } }
+        end
+        let(:expected) { { posts: [:awesome], sample: %i[hello moin gutentach], run_session: [] } }
       end
     end
   end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -172,7 +172,6 @@ describe RequestHandler do
 
       handler = IntegrationTestRequestHandlerWithBody.new(request: request)
       dto = handler.to_dto
-
       expect(dto.body).to eq(id:         'fer342ref',
                              type:       'post',
                              user_id:    'awesome_user_id',


### PR DESCRIPTION
valid types for fieldsets now are: 
- true: All fields are returned
- false: No fields are returned
- Enum: given fields are returned