### PR TITLE
update dependencies and drop ruby 2.1 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 # minitest specifics
 AllCops:
   TargetRubyVersion: 2.1
+  Exclude:
+    - Dangerfile
 Metrics/LineLength:
   Max: 119
 Metrics/MethodLength:
@@ -13,5 +15,7 @@ Style/ClassAndModuleChildren:
   Exclude:
     - test/**/*
 
+Metrics/BlockLength:
+  Enabled: false
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 # minitest specifics
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   Exclude:
     - Dangerfile
 Metrics/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1
@@ -13,9 +12,6 @@ env:
   - "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
 matrix:
   exclude:
-    - rvm: 2.1.10
-      jdk: oraclejdk8
-      env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
     - rvm: 2.2.7
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.1.7.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - jruby-9.1.8.0
 jdk:
   - oraclejdk8
 env:
@@ -16,21 +16,21 @@ matrix:
     - rvm: 2.1.10
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
-    - rvm: 2.2.6
+    - rvm: 2.2.7
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
-    - rvm: 2.3.3
+    - rvm: 2.3.4
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
   allow_failures:
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.8.0
       jdk: oraclejdk8
       env: "JRUBY_OPTS='-Xcompile.invokedynamic=true --debug'"
 before_install:
   - gem update --system
-  - gem install bundler -v 1.13.6
+  - gem install bundler -v 1.14.6
 before_script:
   - bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- update rubocop and fix danger check
+
 ## 0.11.0
 
 - Parse `included` array from request body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## master
 
 - update rubocop and fix danger check
+- drop support for ruby 2.1 (dry-types does not support it anymore either which makes supporting it here pointless)
 
 ## 0.11.0
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,24 +3,24 @@
 # --------------------------------------------------------------------------------------------------------------------
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 has_test_changes = !git.modified_files.grep(/spec/).empty?
-is_version_bump = git.modified_files.sort == ["CHANGELOG.md", "lib/request_handler/version.rb"].sort
+is_version_bump = git.modified_files.sort == ['CHANGELOG.md', 'lib/request_handler/version.rb'].sort
 
 if has_app_changes && !has_test_changes && !is_version_bump
   warn("Tests were not updated. That's OK if you're refactoring existing code.", sticky: false)
 end
 
-if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
-  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/request_handler/request_handler/blob/master/CHANGELOG.md).")
-  message "Note, we hard-wrap at 80 chars and use 2 spaces after the last line."
+if !git.modified_files.include?('CHANGELOG.md') && has_app_changes
+  raise("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/request_handler/request_handler/blob/master/CHANGELOG.md).")
+  message 'Note, we hard-wrap at 80 chars and use 2 spaces after the last line.'
 end
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
+warn('PR is classed as Work in Progress') if github.pr_title.include? 'WIP'
 
 # Warn when there is a big PR
-warn("Big PR") if git.lines_of_code > 500
+warn('Big PR') if git.lines_of_code > 500
 
 commit_lint.check warn: :all, disable: [:subject_cap]
 
 # rubocop
-rubocop.lint "*"
+rubocop.lint git.modified_files + git.added_files

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,7 +11,6 @@ end
 
 if !git.modified_files.include?('CHANGELOG.md') && has_app_changes
   raise("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/request_handler/request_handler/blob/master/CHANGELOG.md).")
-  message 'Note, we hard-wrap at 80 chars and use 2 spaces after the last line.'
 end
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
@@ -23,4 +22,4 @@ warn('Big PR') if git.lines_of_code > 500
 commit_lint.check warn: :all, disable: [:subject_cap]
 
 # rubocop
-rubocop.lint git.modified_files + git.added_files
+rubocop.lint

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dry-request_handler.gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 task :init do

--- a/lib/request_handler.rb
+++ b/lib/request_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/version'
 require 'request_handler/base'
 require 'confstruct'

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/filter_parser'
 require 'request_handler/page_parser'
 require 'request_handler/include_option_parser'

--- a/lib/request_handler/body_parser.rb
+++ b/lib/request_handler/body_parser.rb
@@ -5,7 +5,7 @@ require 'request_handler/error'
 module RequestHandler
   class BodyParser < SchemaParser
     def initialize(request:, schema:, schema_options: {}, included_schemas: {})
-      raise MissingArgumentError, :"request.body" => 'is missing' if request.body.nil?
+      raise MissingArgumentError, "request.body": 'is missing' if request.body.nil?
       super(schema: schema, schema_options: schema_options)
       @request = request
       @included_schemas = included_schemas

--- a/lib/request_handler/body_parser.rb
+++ b/lib/request_handler/body_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/schema_parser'
 require 'request_handler/error'
 module RequestHandler

--- a/lib/request_handler/error.rb
+++ b/lib/request_handler/error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RequestHandler
   class BaseError < StandardError
     attr_reader :errors

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/schema_parser'
 require 'request_handler/error'
 module RequestHandler

--- a/lib/request_handler/filter_parser.rb
+++ b/lib/request_handler/filter_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/schema_parser'
 require 'request_handler/error'
 module RequestHandler

--- a/lib/request_handler/header_parser.rb
+++ b/lib/request_handler/header_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/error'
 module RequestHandler
   class HeaderParser

--- a/lib/request_handler/helper.rb
+++ b/lib/request_handler/helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module RequestHandler
   module Helper
     # extracted out of active_support

--- a/lib/request_handler/include_option_parser.rb
+++ b/lib/request_handler/include_option_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/option_parser'
 require 'request_handler/error'
 module RequestHandler

--- a/lib/request_handler/option_parser.rb
+++ b/lib/request_handler/option_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/error'
 module RequestHandler
   class OptionParser

--- a/lib/request_handler/page_parser.rb
+++ b/lib/request_handler/page_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/error'
 module RequestHandler
   class PageParser
@@ -25,7 +26,7 @@ module RequestHandler
 
     private
 
-    TOP_LEVEL_PAGE_KEYS = Set.new([:default_size, :max_size])
+    TOP_LEVEL_PAGE_KEYS = Set.new(%i[default_size max_size])
     attr_reader :page_options, :config
 
     def check_for_missing_options(config)

--- a/lib/request_handler/schema_parser.rb
+++ b/lib/request_handler/schema_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/error'
 module RequestHandler
   class SchemaParser

--- a/lib/request_handler/sort_option_parser.rb
+++ b/lib/request_handler/sort_option_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'request_handler/option_parser'
 require 'request_handler/error'
 require 'request_handler/sort_option'

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -1,10 +1,9 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'request_handler/version'
-
-# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'request_handler'
   spec.version       = RequestHandler::VERSION
@@ -36,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codecov'
 
   spec.add_development_dependency 'rubocop_runner', '~> 2.0'
-  spec.add_development_dependency 'rubocop', '~> 0.46.0'
+  spec.add_development_dependency 'rubocop', '~> 0.48.1'
 
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'shared base for request_handler using dry-* gems'
   spec.homepage      = 'https://github.com/runtastic/request_handler'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '~> 2.2'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/spec/integration/fieldsets_parser_spec.rb
+++ b/spec/integration/fieldsets_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 describe RequestHandler do
   let(:testclass) do
@@ -21,7 +22,7 @@ describe RequestHandler do
   it 'works for a valid request' do
     request = build_mock_request(params: { 'fields' => { 'posts' => 'foo,bar' } }, headers: nil, body: '')
     testhandler = testclass.new(request: request)
-    expect(testhandler.to_dto).to eq(OpenStruct.new(fieldsets: { posts: [:foo, :bar] }))
+    expect(testhandler.to_dto).to eq(OpenStruct.new(fieldsets: { posts: %i[foo bar] }))
   end
 
   it 'raises an OptionNotAllowedError if the client sends a type not allowed on the server' do
@@ -36,7 +37,7 @@ describe RequestHandler do
     expect { testhandler.to_dto }.to raise_error(RequestHandler::ExternalArgumentError)
   end
   it 'raises an OptionNotAllowedError if the client sends a value that is not allowed for a type' do
-    testclass.config.fieldsets.allowed.posts = %w(foo bar)
+    testclass.config.fieldsets.allowed.posts = %w[foo bar]
     request = build_mock_request(params: { 'fields' => { 'posts' => 'foo' } }, headers: nil, body: '')
     testhandler = testclass.new(request: request)
     expect { testhandler.to_dto }.to raise_error(RequestHandler::InternalArgumentError)

--- a/spec/integration/header_parser_spec.rb
+++ b/spec/integration/header_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 describe RequestHandler do
   context 'HeaderParser' do

--- a/spec/integration/option_parser_spec.rb
+++ b/spec/integration/option_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 describe RequestHandler do
   context 'Option Parser' do
@@ -8,7 +9,7 @@ describe RequestHandler do
           options do
             include_options do
               allowed Dry::Types['strict.string'].enum('user', 'groups')
-              defaults [:foo, :bar]
+              defaults %i[foo bar]
             end
           end
           def to_dto

--- a/spec/integration/page_parser_spec.rb
+++ b/spec/integration/page_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RequestHandler do

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 describe RequestHandler do
   context 'SchemaParser' do
@@ -56,7 +57,7 @@ describe RequestHandler do
             end
             def to_dto
               OpenStruct.new(
-                body:  body_params
+                body: body_params
               )
             end
           end

--- a/spec/request_handler/base_spec.rb
+++ b/spec/request_handler/base_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/base'
 
@@ -64,8 +65,8 @@ describe RequestHandler::Base do
     context 'with hash defaults' do
       let(:tested_defaults) do
         {
-          input:  [:test1, :test2],
-          output: (runstub.run.empty? ? [:test1, :test2] : runstub.run)
+          input:  %i[test1 test2],
+          output: (runstub.run.empty? ? %i[test1 test2] : runstub.run)
         }
       end
       it_behaves_like 'default_handling'
@@ -73,8 +74,8 @@ describe RequestHandler::Base do
     context 'with proc defaults' do
       let(:tested_defaults) do
         {
-          input:  ->(_request) { [:test1, :test2] },
-          output: (runstub.run.empty? ? [:test1, :test2] : runstub.run)
+          input:  ->(_request) { %i[test1 test2] },
+          output: (runstub.run.empty? ? %i[test1 test2] : runstub.run)
         }
       end
       it_behaves_like 'default_handling'
@@ -304,7 +305,7 @@ describe RequestHandler::Base do
   end
 
   context '#params' do
-    let(:testclass) {Class.new(described_class)}
+    let(:testclass) { Class.new(described_class) }
     it 'tranforms the params dots to undescores before using them' do
       request = instance_double('Rack::Request',
                                 params:
@@ -341,16 +342,16 @@ describe RequestHandler::Base do
                'a_symbol_with__separator' => 'omgwtf')
     end
 
-    it "transforms nested arrays" do
+    it 'transforms nested arrays' do
       request = instance_double('Rack::Request',
                                 params:
                                         {
-                                          'nested'       => [{ 'hash.key.in.array' => 'test2' }, "normal.array.element"]
+                                          'nested' => [{ 'hash.key.in.array' => 'test2' }, 'normal.array.element']
                                         },
                                 env:    {},
                                 body:   StringIO.new('body'))
       expect(testclass.new(request: request).send(:params))
-        .to eq('nested' => [{ 'hash__key__in__array' => 'test2' }, "normal.array.element"])
+        .to eq('nested' => [{ 'hash__key__in__array' => 'test2' }, 'normal.array.element'])
     end
   end
 

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/body_parser'
 describe RequestHandler::BodyParser do

--- a/spec/request_handler/configuration_spec.rb
+++ b/spec/request_handler/configuration_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe RequestHandler do
   around do |example|
     default_config = RequestHandler.configuration.dup

--- a/spec/request_handler/error_spec.rb
+++ b/spec/request_handler/error_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RequestHandler::BaseError do

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 describe RequestHandler::FieldsetsParser do
   let(:opts) do
@@ -49,7 +50,7 @@ describe RequestHandler::FieldsetsParser do
   context 'fieldset settings and multiple parameters are set' do
     it_behaves_like 'returns fieldsets' do
       let(:params)  { { 'fields' => { 'posts' => 'awesome,samples' } } }
-      let(:expected) { { posts: [:awesome, :samples] } }
+      let(:expected) { { posts: %i[awesome samples] } }
     end
   end
 
@@ -62,7 +63,7 @@ describe RequestHandler::FieldsetsParser do
 
   context 'fieldset settings and the required parameters are set' do
     before do
-      opts.required = [:posts, :photos]
+      opts.required = %i[posts photos]
     end
     it_behaves_like 'returns fieldsets' do
       let(:params) { { 'fields' => { 'posts' => 'awesome', 'photos' => 'foo' } } }
@@ -78,7 +79,7 @@ describe RequestHandler::FieldsetsParser do
     end
     context 'one required type is not set in the request' do
       before do
-        opts.required = [:posts, :photos]
+        opts.required = %i[posts photos]
       end
       it_behaves_like 'fails' do
         let(:params) { { 'fields' => { 'photos' => 'bar' } } }

--- a/spec/request_handler/filter_parser_spec.rb
+++ b/spec/request_handler/filter_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/filter_parser'
 describe RequestHandler::FilterParser do

--- a/spec/request_handler/header_parser_spec.rb
+++ b/spec/request_handler/header_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/header_parser'
 describe RequestHandler::HeaderParser do

--- a/spec/request_handler/include_option_parser_spec.rb
+++ b/spec/request_handler/include_option_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/include_option_parser'
 describe RequestHandler::IncludeOptionParser do
@@ -20,13 +21,13 @@ describe RequestHandler::IncludeOptionParser do
 
   context 'option is allowed' do
     let(:params) { { 'include' => 'user,email' } }
-    let(:output) { [:user, :email] }
+    let(:output) { %i[user email] }
     it_behaves_like 'proccesses valid options correctly'
   end
 
   context 'nested attributes are correctly transformed' do
     let(:params) { { 'include' => 'user,user.posts' } }
-    let(:output) { [:user, :user__posts] }
+    let(:output) { %i[user user__posts] }
     it_behaves_like 'proccesses valid options correctly'
   end
 

--- a/spec/request_handler/option_parser_spec.rb
+++ b/spec/request_handler/option_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/option_parser.rb'
 describe RequestHandler::OptionParser do

--- a/spec/request_handler/page_parser_spec.rb
+++ b/spec/request_handler/page_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/page_parser'
 describe RequestHandler::PageParser do

--- a/spec/request_handler/schema_parser_spec.rb
+++ b/spec/request_handler/schema_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/schema_parser'
 describe RequestHandler::SchemaParser do

--- a/spec/request_handler/sort_option_parser_spec.rb
+++ b/spec/request_handler/sort_option_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'request_handler/sort_option_parser'
 describe RequestHandler::SortOptionParser do

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'ostruct'
 class IntegrationTestRequestHandler < RequestHandler::Base
@@ -36,7 +37,7 @@ class IntegrationTestRequestHandler < RequestHandler::Base
                optional(:posts__awesome).filled(:bool?)
                optional(:posts__samples__photos__has_thumbnail).filled(:bool?)
              end)
-      additional_url_filter %i(user_id)
+      additional_url_filter %i[user_id]
     end
 
     include_options do
@@ -97,7 +98,7 @@ class IntegrationTestRequestHandlerWithBody < RequestHandler::Base
                required(:user_id).value(eql?: body_user_id)
                required(:id).filled(:str?)
              end)
-      additional_url_filter %i(user_id id)
+      additional_url_filter %i[user_id id]
       options(->(handler, _request) { { body_user_id: handler.body_params[:user_id] } })
     end
   end
@@ -236,13 +237,13 @@ describe RequestHandler do
                              assets__size:                 10,
                              assets__number:               1)
 
-      expect(dto.include).to eq(%i(user groups user__avatar))
+      expect(dto.include).to eq(%i[user groups user__avatar])
 
       expect(dto.sort).to eq([RequestHandler::SortOption.new('name', :asc),
                               RequestHandler::SortOption.new('age', :desc)])
 
       expect(dto.headers).to eq(expected_headers)
-      expect(dto.fieldsets).to eq(posts: [:samples, :awesome])
+      expect(dto.fieldsets).to eq(posts: %i[samples awesome])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ENV['RACK_ENV'] = ENV['ENVIRONMENT'] ||= 'test'
 require 'simplecov'
 if ENV['TRAVIS']

--- a/spec/support/helper.rb
+++ b/spec/support/helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 def build_mock_request(params:, headers:, body: '')
   instance_double('Rack::Request', params: params, env: headers, body: StringIO.new(body))
 end


### PR DESCRIPTION
dry-types dropped support for ruby 2.1 which makes it pointless to support it here. It simply silently breaks all kind of type checks.