### PR TITLE
added errors for different params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Changelog
 - drop support for ruby 2.1 (dry-types does not support it anymore either which makes supporting it here pointless)
 - adapt fieldset validation to allow all fields in addition to a specific enum
 
+## 0.12.0
+
+- Throw different errors for each parser
+- all new errors inherit from ExternalArgumentError
+
 ## 0.11.0
 
 - Parse `included` array from request body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ Changelog
 - update rubocop and fix danger check
 - drop support for ruby 2.1 (dry-types does not support it anymore either which makes supporting it here pointless)
 - adapt fieldset validation to allow all fields in addition to a specific enum
-
-## 0.12.0
-
-- Throw different errors for each parser
-- all new errors inherit from ExternalArgumentError
+- throw different errors for each parser, all new errors inherit from ExternalArgumentError
 
 ## 0.11.0
 

--- a/lib/request_handler/body_parser.rb
+++ b/lib/request_handler/body_parser.rb
@@ -25,7 +25,7 @@ module RequestHandler
 
     def flattened_request_body
       body = request_body.fetch('data') do
-        raise ExternalArgumentError, body: 'must contain data'
+        raise BodyParamsError, body: 'must contain data'
       end
       [flatten_resource!(body), *parse_included]
     end

--- a/lib/request_handler/error.rb
+++ b/lib/request_handler/error.rb
@@ -30,4 +30,17 @@ module RequestHandler
   end
   class NoConfigAvailableError < InternalBaseError
   end
+
+  class BodyParamsError < ExternalArgumentError
+  end
+  class FieldsetsParamsError < ExternalArgumentError
+  end
+  class FilterParamsError < ExternalArgumentError
+  end
+  class IncludeParamsError < ExternalArgumentError
+  end
+  class PageParamsError < ExternalArgumentError
+  end
+  class SortParamsError < ExternalArgumentError
+  end
 end

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -42,12 +42,12 @@ module RequestHandler
         allowed[type].call(option).to_sym
       end
     rescue Dry::Types::ConstraintError
-      raise ExternalArgumentError, fieldsets: "invalid field: <#{option}> for type: #{type}"
+      raise FieldsetsParamsError, fieldsets: "invalid field: <#{option}> for type: #{type}"
     end
 
     def check_required_fieldsets_types(fieldsets)
       return fieldsets if (required - fieldsets.keys).empty?
-      raise ExternalArgumentError, fieldsets: 'missing required fieldsets parameter'
+      raise FieldsetsParamsError, fieldsets: 'missing required fieldsets parameter'
     end
 
     def raise_invalid_field_option(type)
@@ -57,7 +57,7 @@ module RequestHandler
 
     def raise_missing_fields_param
       return if required.empty?
-      raise ExternalArgumentError, fieldsets: 'missing required fields options'
+      raise FieldsetsParamsError, fieldsets: 'missing required fields options'
     end
 
     attr_reader :params, :allowed, :required

--- a/lib/request_handler/filter_parser.rb
+++ b/lib/request_handler/filter_parser.rb
@@ -7,7 +7,7 @@ module RequestHandler
     def initialize(params:, schema:, additional_url_filter:, schema_options: {})
       super(schema: schema, schema_options: schema_options)
       @filter = params.fetch('filter') { {} }
-      raise ExternalArgumentError, filter: 'must be a Hash' unless @filter.is_a?(Hash)
+      raise FilterParamsError, filter: 'must be a Hash' unless @filter.is_a?(Hash)
       Array(additional_url_filter).each do |key|
         key = key.to_s
         raise build_error(key) unless @filter[key].nil?

--- a/lib/request_handler/include_option_parser.rb
+++ b/lib/request_handler/include_option_parser.rb
@@ -7,7 +7,7 @@ module RequestHandler
     def run
       return [] unless params.key?('include')
       options = fetch_options
-      raise ExternalArgumentError, include: 'must not contain a space' if options.include? ' '
+      raise IncludeParamsError, include: 'must not contain a space' if options.include? ' '
       allowed_options(options.split(','))
     end
 
@@ -23,7 +23,7 @@ module RequestHandler
     end
 
     def fetch_options
-      raise ExternalArgumentError, include_options: 'query paramter must not be empty' if empty_param?('include')
+      raise IncludeParamsError, include_options: 'query paramter must not be empty' if empty_param?('include')
       params.fetch('include') { '' }
     end
   end

--- a/lib/request_handler/page_parser.rb
+++ b/lib/request_handler/page_parser.rb
@@ -9,7 +9,7 @@ module RequestHandler
       missing_arguments << { page_config: 'is missing' } if page_config.nil?
       raise MissingArgumentError, missing_arguments unless missing_arguments.empty?
       @page_options = params.fetch('page') { {} }
-      raise ExternalArgumentError, page: 'must be a Hash' unless @page_options.is_a?(Hash)
+      raise PageParamsError, page: 'must be a Hash' unless @page_options.is_a?(Hash)
       @config = page_config
     end
 
@@ -65,10 +65,10 @@ module RequestHandler
 
     def check_int(string:, error_msg:)
       output = Integer(string)
-      raise ExternalArgumentError, error_msg unless output > 0
+      raise PageParamsError, error_msg unless output > 0
       output
     rescue ArgumentError
-      raise ExternalArgumentError, error_msg
+      raise PageParamsError, error_msg
     end
 
     def apply_max_size_constraint(size, prefix)

--- a/lib/request_handler/sort_option_parser.rb
+++ b/lib/request_handler/sort_option_parser.rb
@@ -8,12 +8,12 @@ module RequestHandler
     def run
       return [] unless params.key?('sort')
       sort_options = parse_options(fetch_options)
-      raise ExternalArgumentError, sort_options: 'must be unique' if duplicates?(sort_options)
+      raise SortParamsError, sort_options: 'must be unique' if duplicates?(sort_options)
       sort_options
     end
 
     def fetch_options
-      raise ExternalArgumentError, sort_options: 'the query paramter must not be empty' if empty_param?('sort')
+      raise SortParamsError, sort_options: 'the query paramter must not be empty' if empty_param?('sort')
       params.fetch('sort') { '' }.split(',')
     end
 
@@ -27,7 +27,7 @@ module RequestHandler
     end
 
     def parse_option(option)
-      raise ExternalArgumentError, sort_options: 'must not contain a space' if option.include? ' '
+      raise SortParamsError, sort_options: 'must not contain a space' if option.include? ' '
       if option.start_with?('-')
         [option[1..-1], :desc]
       else

--- a/spec/integration/fieldsets_parser_spec.rb
+++ b/spec/integration/fieldsets_parser_spec.rb
@@ -34,7 +34,7 @@ describe RequestHandler do
   it 'raises an OptionNotAllowedError if the client sends a value that is not allowed for a type' do
     request = build_mock_request(params: { 'fields' => { 'posts' => 'no' } }, headers: nil, body: '')
     testhandler = testclass.new(request: request)
-    expect { testhandler.to_dto }.to raise_error(RequestHandler::ExternalArgumentError)
+    expect { testhandler.to_dto }.to raise_error(RequestHandler::FieldsetsParamsError)
   end
   it 'raises an OptionNotAllowedError if the client sends a value that is not allowed for a type' do
     testclass.config.fieldsets.allowed.posts = %w[foo bar]

--- a/spec/integration/option_parser_spec.rb
+++ b/spec/integration/option_parser_spec.rb
@@ -27,7 +27,7 @@ describe RequestHandler do
       it 'raises an ExternalArgumentError if the query parameter contains as space' do
         request = build_mock_request(params: { 'include' => 'user, groups' }, headers: {}, body: '')
         testhandler = testclass.new(request: request)
-        expect { testhandler.to_dto }.to raise_error(RequestHandler::ExternalArgumentError)
+        expect { testhandler.to_dto }.to raise_error(RequestHandler::IncludeParamsError)
       end
       it 'raises a InternalArgumentError if params is set to nil' do
         request = build_mock_request(params: nil, headers: {}, body: '')
@@ -68,7 +68,7 @@ describe RequestHandler do
       it 'raises an ExternalArgumentError if the query parameter contains as space' do
         request = build_mock_request(params: { 'sort' => 'name, age' }, headers: {}, body: '')
         testhandler = testclass.new(request: request)
-        expect { testhandler.to_dto }.to raise_error(RequestHandler::ExternalArgumentError)
+        expect { testhandler.to_dto }.to raise_error(RequestHandler::SortParamsError)
       end
       it 'raises an MissingArgumentError if params is set to nil' do
         request = build_mock_request(params: nil, headers: {}, body: '')

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -409,6 +409,6 @@ describe RequestHandler::BodyParser do
                                  body: StringIO.new('{"include": [{"type": "foo", "id": "bar"}]}'))
       ).run
     end
-      .to raise_error(RequestHandler::ExternalArgumentError)
+      .to raise_error(RequestHandler::BodyParamsError)
   end
 end

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -27,7 +27,7 @@ describe RequestHandler::FieldsetsParser do
   end
 
   shared_examples 'fails' do
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::FieldsetsParamsError }
     it 'raises an error' do
       expect do
         described_class.new(params:   params,

--- a/spec/request_handler/filter_parser_spec.rb
+++ b/spec/request_handler/filter_parser_spec.rb
@@ -118,6 +118,6 @@ describe RequestHandler::FilterParser do
       required('name').filled
     end
     expect { described_class.new(schema: schema, params: params, additional_url_filter: additional_url_filter) }
-      .to raise_error(RequestHandler::ExternalArgumentError)
+      .to raise_error(RequestHandler::FilterParamsError)
   end
 end

--- a/spec/request_handler/include_option_parser_spec.rb
+++ b/spec/request_handler/include_option_parser_spec.rb
@@ -40,13 +40,13 @@ describe RequestHandler::IncludeOptionParser do
   context 'no include options are specified' do
     let(:params) { { 'include' => '' } }
     let(:output) { [] }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::IncludeParamsError }
     it_behaves_like 'proccesses invalid options correctly'
   end
 
   context 'options contain a space' do
     let(:params) { { 'include' => 'user, email' } }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::IncludeParamsError }
     it_behaves_like 'proccesses invalid options correctly'
   end
 

--- a/spec/request_handler/page_parser_spec.rb
+++ b/spec/request_handler/page_parser_spec.rb
@@ -110,7 +110,7 @@ describe RequestHandler::PageParser do
     end
 
     context 'number is set to a non integer string' do
-      let(:error) { RequestHandler::ExternalArgumentError }
+      let(:error) { RequestHandler::PageParamsError }
       let(:params) do
         { 'page' => {
           'users__size'   => '40',
@@ -121,7 +121,7 @@ describe RequestHandler::PageParser do
     end
 
     context 'number is set to a negative string' do
-      let(:error) { RequestHandler::ExternalArgumentError }
+      let(:error) { RequestHandler::PageParamsError }
       let(:params) do
         { 'page' => {
           'users__size'   => '40',
@@ -132,7 +132,7 @@ describe RequestHandler::PageParser do
     end
 
     context 'size is set to a negative string' do
-      let(:error) { RequestHandler::ExternalArgumentError }
+      let(:error) { RequestHandler::PageParamsError }
       let(:params) do
         { 'page' => {
           'users__size'   => '-40',
@@ -143,7 +143,7 @@ describe RequestHandler::PageParser do
     end
 
     context 'size is set to a non integer string' do
-      let(:error) { RequestHandler::ExternalArgumentError }
+      let(:error) { RequestHandler::PageParamsError }
       let(:params) do
         { 'page' => {
           'users__size'   => 'asdf',

--- a/spec/request_handler/sort_option_parser_spec.rb
+++ b/spec/request_handler/sort_option_parser_spec.rb
@@ -51,7 +51,7 @@ describe RequestHandler::SortOptionParser do
   context 'no sort options are specified' do
     let(:params) { { 'sort' => '' } }
     let(:output) { [] }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::SortParamsError }
     it_behaves_like 'processes invalid sort options correctly'
   end
 
@@ -63,19 +63,19 @@ describe RequestHandler::SortOptionParser do
 
   context 'sort key is not unique and the order is different in the duplicate' do
     let(:params) { { 'sort' => 'id,-id' } }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::SortParamsError }
     it_behaves_like 'processes invalid sort options correctly'
   end
 
   context 'sort key is not unique and the order is identical in the duplicate' do
     let(:params) { { 'sort' => 'id,id' } }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::SortParamsError }
     it_behaves_like 'processes invalid sort options correctly'
   end
 
   context 'one of the sort keys contains spaces' do
     let(:params) { { 'sort' => 'id, foo' } }
-    let(:error) { RequestHandler::ExternalArgumentError }
+    let(:error) { RequestHandler::SortParamsError }
     it_behaves_like 'processes invalid sort options correctly'
   end
 


### PR DESCRIPTION
As we may need to handle the ExternalArgumentErrors for each parser differently in our projects, the errors are now separated in more expressive exceptions.