### PR TITLE
Add support for generic query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## master
 
+- support generic query params
+
 ## 0.13.0
 
 - sidecar resources for multipart requests can be labeled with required

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Please note that pagination only considers options that are configured on the
 server (at least an empty configuration block int the page block), other options
 sent by the client are ignored and will cause a warning.
 
+Generic query params can be added by using the `query` block. This may be useful
+if parameters should be validated which cannot be assigned to other predefined option blocks.
+
 ```ruby
 require "dry-validation"
 require "request_handler"
@@ -76,6 +79,14 @@ class DemoHandler < RequestHandler::Base
       additional_url_filter %i(user_id id)
       options(->(_handler, _request) { { foo: "bar" } })
       # options({foo: "bar"}) # also works for hash options instead of procs
+    end
+
+    query do
+      schema(
+        Dry::Validation.Form do
+          optional(:name).filled(:str?)
+        end
+      )
     end
 
     body do

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -8,6 +8,7 @@ require 'request_handler/header_parser'
 require 'request_handler/body_parser'
 require 'request_handler/multipart_parser'
 require 'request_handler/fieldsets_parser'
+require 'request_handler/query_parser'
 require 'request_handler/helper'
 require 'confstruct'
 module RequestHandler
@@ -65,6 +66,10 @@ module RequestHandler
       @fieldsets_params ||= parse_fieldsets_params
     end
 
+    def query_params
+      @query_params ||= parse_query_params
+    end
+
     # @abstract Subclass is expected to implement #to_dto
     # !method to_dto
     #   take the parsed values and return as application specific data transfer object
@@ -119,6 +124,14 @@ module RequestHandler
       FieldsetsParser.new(params:   params,
                           allowed:  lookup!('fieldsets.allowed'),
                           required: lookup('fieldsets.required') || []).run
+    end
+
+    def parse_query_params
+      QueryParser.new(
+        params:         params,
+        schema:         lookup!('query.schema'),
+        schema_options: execute_options(lookup('query.options'))
+      ).run
     end
 
     def fetch_defaults(key, default)

--- a/lib/request_handler/query_parser.rb
+++ b/lib/request_handler/query_parser.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'request_handler/schema_parser'
+require 'request_handler/error'
+module RequestHandler
+  class QueryParser < SchemaParser
+    RESERVED_KEYS = %w(fields filter include page sort)
+
+    def initialize(params:, schema:, schema_options: {})
+      super(schema: schema, schema_options: schema_options)
+      @query = params.clone
+      RESERVED_KEYS.each { |key| query.delete(key) }
+    end
+
+    def run
+      validate_schema(query)
+    end
+
+    private
+
+    attr_reader :query
+  end
+end

--- a/lib/request_handler/query_parser.rb
+++ b/lib/request_handler/query_parser.rb
@@ -4,7 +4,7 @@ require 'request_handler/schema_parser'
 require 'request_handler/error'
 module RequestHandler
   class QueryParser < SchemaParser
-    RESERVED_KEYS = %w(fields filter include page sort)
+    RESERVED_KEYS = %w[fields filter include page sort].freeze
 
     def initialize(params:, schema:, schema_options: {})
       super(schema: schema, schema_options: schema_options)

--- a/lib/request_handler/query_parser.rb
+++ b/lib/request_handler/query_parser.rb
@@ -8,7 +8,7 @@ module RequestHandler
 
     def initialize(params:, schema:, schema_options: {})
       super(schema: schema, schema_options: schema_options)
-      @query = params.clone
+      @query = params.dup
       RESERVED_KEYS.each { |key| query.delete(key) }
     end
 

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -187,7 +187,7 @@ describe RequestHandler do
             end
             def to_dto
               OpenStruct.new(
-                query:  query_params
+                query: query_params
               )
             end
           end
@@ -207,7 +207,7 @@ describe RequestHandler do
         it 'works for valid data' do
           request = build_mock_request(params: valid_params, headers: {}, body: '')
           testhandler = testclass.new(request: request)
-          expect(testhandler.to_dto).to eq(OpenStruct.new(query: { name: 'foo'}))
+          expect(testhandler.to_dto).to eq(OpenStruct.new(query: { name: 'foo' }))
         end
       end
       context 'invalid schema' do

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -157,5 +157,80 @@ describe RequestHandler do
         end
       end
     end
+
+    context 'QueryParser' do
+      let(:valid_params) do
+        {
+          'name' => 'foo',
+          'filter' => {
+            'post' => 'bar'
+          }
+        }
+      end
+      let(:invalid_params) do
+        {
+          'name' => nil,
+          'filter' => {
+            'post' => 'bar'
+          }
+        }
+      end
+      context 'valid schema' do
+        let(:testclass) do
+          Class.new(RequestHandler::Base) do
+            options do
+              query do
+                schema(Dry::Validation.Form do
+                  optional(:name).filled(:str?)
+                end)
+              end
+            end
+            def to_dto
+              OpenStruct.new(
+                query:  query_params
+              )
+            end
+          end
+        end
+        it 'raises a SchemaValidationError with invalid data' do
+          request = build_mock_request(params: invalid_params, headers: {}, body: '')
+          testhandler = testclass.new(request: request)
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::SchemaValidationError)
+        end
+
+        it 'raises a MissingArgumentError with missing data' do
+          request = build_mock_request(params: nil, headers: {}, body: '')
+          testhandler = testclass.new(request: request)
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::MissingArgumentError)
+        end
+
+        it 'works for valid data' do
+          request = build_mock_request(params: valid_params, headers: {}, body: '')
+          testhandler = testclass.new(request: request)
+          expect(testhandler.to_dto).to eq(OpenStruct.new(query: { name: 'foo'}))
+        end
+      end
+      context 'invalid schema' do
+        let(:testclass) do
+          Class.new(RequestHandler::Base) do
+            options do
+              query do
+                schema 'Foo'
+              end
+            end
+            def to_dto
+              OpenStruct.new(
+                query: query_params
+              )
+            end
+          end
+        end
+        it 'raises a InternalArgumentError with valid data' do
+          request = build_mock_request(params: valid_params, headers: {}, body: '')
+          testhandler = testclass.new(request: request)
+          expect { testhandler.to_dto }.to raise_error(RequestHandler::InternalArgumentError)
+        end
+      end
+    end
   end
 end

--- a/spec/request_handler/query_parser_spec.rb
+++ b/spec/request_handler/query_parser_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'request_handler/query_parser'
+describe RequestHandler::QueryParser do
+  shared_examples 'proccesses query params correctly' do
+    it 'outputs the query params in a flat way' do
+      handler = described_class.new(schema: schema, params: params)
+      expect(handler.run).to eq(output)
+    end
+  end
+
+  context 'one query param' do
+    let(:params) do
+      { 'name' => 'foo' } 
+    end
+    let(:schema) do
+      Dry::Validation.Schema do
+        required('name').filled
+      end
+    end
+    let(:output)  do
+      { 'name' => 'foo' }
+    end
+    it_behaves_like 'proccesses query params correctly'
+  end
+
+  context 'one query param and multiple reserved params' do
+    let(:params) do
+      {
+        'name'   => 'foo',
+        'page' => {
+          'number' => '1',
+          'size' => '5'
+        },
+        'sort'  => 'id,-date',
+        'fields' => {
+          'posts' => 'awesome'
+        },
+        'include' => 'user,email',
+        'filter' => {
+          'name' => 'bar'
+        }
+      }
+    end
+    let(:schema) do
+      Dry::Validation.Schema do
+        required('name').filled
+      end end
+    let(:output) do
+      {
+        'name' => 'foo'
+      }
+    end
+    it_behaves_like 'proccesses query params correctly'
+  end
+
+  context 'no query params set' do
+    let(:params) { {} }
+    let(:schema) { Dry::Validation.Schema {} }
+    let(:output) { {} }
+    it_behaves_like 'proccesses query params correctly'
+  end
+
+  context 'optional query param' do
+    let(:schema) do
+      Dry::Validation.Schema do
+        optional('name').filled
+      end
+    end
+    context 'param given' do
+      let(:params) do
+        { 'name' => 'foo' } 
+      end
+      let(:output) do
+        {
+          'name' => 'foo'
+        }
+      end
+      it_behaves_like 'proccesses query params correctly'
+    end
+
+    context 'param not given' do
+      let(:params) { {} }
+      let(:output) { {} }
+      it_behaves_like 'proccesses query params correctly'
+    end
+  end
+end

--- a/spec/request_handler/query_parser_spec.rb
+++ b/spec/request_handler/query_parser_spec.rb
@@ -12,7 +12,7 @@ describe RequestHandler::QueryParser do
 
   context 'one query param' do
     let(:params) do
-      { 'name' => 'foo' } 
+      { 'name' => 'foo' }
     end
     let(:schema) do
       Dry::Validation.Schema do
@@ -28,12 +28,12 @@ describe RequestHandler::QueryParser do
   context 'one query param and multiple reserved params' do
     let(:params) do
       {
-        'name'   => 'foo',
+        'name' => 'foo',
         'page' => {
           'number' => '1',
           'size' => '5'
         },
-        'sort'  => 'id,-date',
+        'sort' => 'id,-date',
         'fields' => {
           'posts' => 'awesome'
         },
@@ -70,7 +70,7 @@ describe RequestHandler::QueryParser do
     end
     context 'param given' do
       let(:params) do
-        { 'name' => 'foo' } 
+        { 'name' => 'foo' }
       end
       let(:output) do
         {

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -40,6 +40,12 @@ class IntegrationTestRequestHandler < RequestHandler::Base
       additional_url_filter %i[user_id]
     end
 
+    query do
+      schema(Dry::Validation.Form do
+               required(:name).filled(:str?)
+             end)
+    end
+
     include_options do
       allowed Dry::Types['strict.string'].enum('user', 'user__avatar', 'groups')
     end
@@ -59,6 +65,7 @@ class IntegrationTestRequestHandler < RequestHandler::Base
   def to_dto
     OpenStruct.new(
       filter:    filter_params,
+      query:     query_params,
       page:      page_params,
       include:   include_params,
       sort:      sort_params,
@@ -226,6 +233,7 @@ describe RequestHandler do
     it 'works' do
       params = {
         'user_id' => '234',
+        'name'    => 'bar',
         'filter'  => {
           'name'                               => 'foo',
           'posts.awesome'                      => 'true',
@@ -277,6 +285,7 @@ describe RequestHandler do
 
       expect(dto.headers).to eq(expected_headers)
       expect(dto.fieldsets).to eq(posts: %i[samples awesome])
+      expect(dto.query).to eq(name: 'bar')
     end
   end
 


### PR DESCRIPTION
This adds support for adding generic query params as it is currently not possible to validate params which cannot be assigned to the predefined options (filter, page, include, fieldset, sort).