### PR TITLE
Bump version of dry-types to 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## master
 
+## 0.15.0
+
+- Bump version for `dry-types` to `0.12.2`
+
 ## 0.14.0
 
 - support generic query params

--- a/lib/request_handler/version.rb
+++ b/lib/request_handler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RequestHandler
-  VERSION = '0.14.0'.freeze
+  VERSION = '0.15.0'.freeze
 end

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-validation', '~> 0.11.0'
-  spec.add_dependency 'dry-types', '~> 0.11.0'
+  spec.add_dependency 'dry-types', '~> 0.12.2'
 
   spec.add_dependency 'confstruct', '~> 1.0.2'
   spec.add_dependency 'multi_json', '~> 1.12'


### PR DESCRIPTION
Just a version bump for `dry-types`.