### PR TITLE
Do not skip relationships with empty data when appending to resource

### DIFF
--- a/lib/request_handler/json_api_document_parser.rb
+++ b/lib/request_handler/json_api_document_parser.rb
@@ -33,7 +33,6 @@ module RequestHandler
     def flatten_relationship_resource_linkages(relationships)
       relationships.each_with_object({}) do |(k, v), memo|
         resource_linkage = v['data']
-        next if resource_linkage.nil?
         memo[k] = resource_linkage
       end
     end

--- a/spec/request_handler/json_api_document_parser_spec.rb
+++ b/spec/request_handler/json_api_document_parser_spec.rb
@@ -216,6 +216,32 @@ describe RequestHandler::JsonApiDocumentParser do
     it_behaves_like 'flattens the body as expected'
   end
 
+  context 'when relationship data is empty' do
+    let(:raw_body) do
+      <<-JSON
+      {
+        "data": {
+          "type": "post",
+          "id": "fer342ref",
+          "relationships":{
+            "category": {
+              "data": null
+            }
+          }
+        }
+      }
+      JSON
+    end
+    let(:wanted_result) do
+      {
+        'id'       => 'fer342ref',
+        'type'     => 'post',
+        'category' => nil
+      }
+    end
+    it_behaves_like 'flattens the body as expected'
+  end
+
   context 'without attributes' do
     let(:raw_body) do
       <<-JSON


### PR DESCRIPTION
To patch/put a resource with a removed relationship, you need to be able to pass it with an empty `data` field. This is currently not possible as the Json Api parser just skips those relationships when flattening/merging them to the resource.