### PR TITLE
allow newer dry-types gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - loosen dry-gems restrictions, now allow all version > 0.11
 
-
 ## [1.0.0] - 2018-07-03
 ### Added
 - possibility to send NULL values in relationships

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- loosen dry-gems restrictions, now allow all version > 0.11
+
 
 ## [1.0.0] - 2018-07-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class DemoHandler < RequestHandler::Base
 
     filter do
       schema(
-        Dry::Validation.Form do
+        Dry::Validation.Params do
           configure do
             option :foo
           end
@@ -91,7 +91,7 @@ class DemoHandler < RequestHandler::Base
 
     query do
       schema(
-        Dry::Validation.Form do
+        Dry::Validation.Params do
           optional(:name).filled(:str?)
         end
       )

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ This gem allows easy and dry handling of requests based on the dry-validation
 gem for validation and data coersion. It allows to handle headers, filters,
 include_options, sorting and of course to validate the body.
 
-## ToDo
+## dry-gem dependency
 
-- update documentation
-- identify missing features compared to [jsonapi](https://jsonapi.org)
+Version 1.1 removes the strict dependency to dry-types v0.11 & dry-validation v0.11 and allows usage of newer versions of dry-gems. This gem uses these gems but only a very small interface with them therefore this gem itself is usually not impacted by smaller breaking changes each minor version of the dry-gems might introduce.
+
+**Please check your applications compatibility with each dry-types version and pin versions as necessary**
 
 ## Installation
 

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-validation', '~> 0.11', '>= 0.11.0'
-  spec.add_dependency 'dry-types', '0.11', '>= 0.11.0'
+  spec.add_dependency 'dry-types', '~> 0.11', '>= 0.11.0'
 
   spec.add_dependency 'confstruct', '~> 1.0.2'
   spec.add_dependency 'multi_json', '~> 1.12'

--- a/request_handler.gemspec
+++ b/request_handler.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dry-validation', '~> 0.11.0'
-  spec.add_dependency 'dry-types', '~> 0.11.0'
+  spec.add_dependency 'dry-validation', '~> 0.11', '>= 0.11.0'
+  spec.add_dependency 'dry-types', '0.11', '>= 0.11.0'
 
   spec.add_dependency 'confstruct', '~> 1.0.2'
   spec.add_dependency 'multi_json', '~> 1.12'

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -172,7 +172,7 @@ describe RequestHandler do
           Class.new(RequestHandler::Base) do
             options do
               filter do
-                schema(Dry::Validation.Form do
+                schema(Dry::Validation.Params do
                   required(:name).filled(:str?)
                 end)
                 defaults(foo: 'bar')
@@ -248,7 +248,7 @@ describe RequestHandler do
           Class.new(RequestHandler::Base) do
             options do
               query do
-                schema(Dry::Validation.Form do
+                schema(Dry::Validation.Params do
                   optional(:name).filled(:str?)
                 end)
               end

--- a/spec/request_handler/schema_parser_spec.rb
+++ b/spec/request_handler/schema_parser_spec.rb
@@ -34,23 +34,23 @@ describe RequestHandler::SchemaParser do
   end
 
   let(:schema_without_options) do
-    Dry::Validation.Form do
+    Dry::Validation.Params do
       configure do
         config.type_specs = true
       end
       required(:test1, :string).filled(:str?)
-      required(:test2, :int).value(gt?: 0)
+      required(:test2, :integer).value(gt?: 0)
       optional(:filter_type_in, Types::ArrayFromCSV).each(Types::SupportedFilterKeys)
     end
   end
   let(:schema_with_options) do
-    Dry::Validation.Form do
+    Dry::Validation.Params do
       configure do
         option :testoption
         config.type_specs = true
       end
       required(:test1, :string).filled(:str?)
-      required(:test2, :int).value(eql?: testoption)
+      required(:test2, :integer).value(eql?: testoption)
       optional(:filter_type_in, Types::ArrayFromCSV).each(Types::SupportedFilterKeys)
     end
   end
@@ -111,10 +111,10 @@ describe RequestHandler::SchemaParser do
 
   context 'data keys get deep_symbolized when schema rules are symbols' do
     let(:schema_without_options) do
-      Dry::Validation.Form do
+      Dry::Validation.Params do
         configure { config.type_specs = true }
 
-        required(:simple, :int).filled(:int?)
+        required(:simple, :integer).filled(:int?)
         optional(:nested, %i[nil hash]).maybe do
           schema do
             required(:attr1).filled(:str?)

--- a/spec/request_handler/sidecar_parser_spec.rb
+++ b/spec/request_handler/sidecar_parser_spec.rb
@@ -25,7 +25,7 @@ describe RequestHandler::JsonParser do
     let(:schema) do
       Dry::Validation.JSON do
         required(:required, :bool).filled(:bool?)
-        optional(:optional, :int).filled(:int?)
+        optional(:optional, :integer).filled(:int?)
         optional(:maybe, :string).maybe(:str?)
       end
     end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -29,7 +29,7 @@ class IntegrationTestRequestHandler < RequestHandler::Base
     end
 
     filter do
-      schema(Dry::Validation.Form do
+      schema(Dry::Validation.Params do
                required(:user_id).filled(:int?)
                required(:name).filled(:str?)
                optional(:age__gt).filled(:int?)
@@ -41,7 +41,7 @@ class IntegrationTestRequestHandler < RequestHandler::Base
     end
 
     query do
-      schema(Dry::Validation.Form do
+      schema(Dry::Validation.Params do
                required(:name).filled(:str?)
              end)
     end
@@ -99,7 +99,7 @@ class IntegrationTestRequestHandlerWithBody < RequestHandler::Base
     end
 
     filter do
-      schema(Dry::Validation.Form do
+      schema(Dry::Validation.Params do
                configure do
                  option :body_user_id
                end


### PR DESCRIPTION
tests are all working again with the latest dry-gem versions

Only test code was impacted - so I would release this only as a minor version. But with the notice that users might need to pin older dry-gem version 

This implicitly solves #29 