### PR TITLE
[WIP] Use hash config instead of confstruct

### DIFF
--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -14,9 +14,8 @@ require 'confstruct'
 module RequestHandler
   class Base
     class << self
-      def options(&block)
-        @config ||= ::Confstruct::Configuration.new
-        @config.configure(&block)
+      def options(hash)
+        @config ||= hash
       end
 
       def inherited(subclass)
@@ -149,13 +148,17 @@ module RequestHandler
     end
 
     def lookup!(key)
-      config.lookup!(key).tap do |data|
+      config.dig(*symbolize_key(key)) do |data|
         raise NoConfigAvailableError, key.to_sym => 'is not configured' if data.nil?
       end
     end
 
     def lookup(key)
-      config.lookup!(key)
+      config.dig(*symbolize_key(key))
+    end
+
+    def symbolize_key(key)
+      key.split('.').map(&:to_sym)
     end
 
     def params

--- a/spec/integration/fieldsets_parser_spec.rb
+++ b/spec/integration/fieldsets_parser_spec.rb
@@ -9,14 +9,15 @@ describe RequestHandler do
       let(:testclass) do
         schema = enum_schema
         Class.new(RequestHandler::Base) do
-          options do
-            fieldsets do
-              allowed do
-                posts(schema)
-              end
-              required [:posts]
-            end
-          end
+          options(
+            fieldsets: {
+              allowed: {
+                posts: schema
+              },
+              required: [:posts]
+            }
+          )
+
           def to_dto
             OpenStruct.new(
               fieldsets: fieldsets_params
@@ -63,7 +64,7 @@ describe RequestHandler do
       end
 
       context 'with a value that is not allowed for a type' do
-        before { testclass.config.fieldsets.allowed.posts = %w[foo bar] }
+        before { testclass.config[:fieldsets][:allowed][:posts] = %w[foo bar] }
         let(:request) { build_mock_request(params: { 'fields' => { 'posts' => 'foo' } }, headers: nil, body: '') }
         it { expect { to_dto }.to raise_error(RequestHandler::InternalArgumentError) }
       end
@@ -72,13 +73,13 @@ describe RequestHandler do
     context 'with optional fieldset' do
       let(:testclass) do
         Class.new(RequestHandler::Base) do
-          options do
-            fieldsets do
-              allowed do
-                posts true
-              end
-            end
-          end
+          options(
+            fieldsets: {
+              allowed: {
+                posts: true
+              }
+            }
+          )
 
           def to_dto
             OpenStruct.new(fieldsets: fieldsets_params)


### PR DESCRIPTION
Confstruct is not compatible with ruby 2.6 so we have to get rid of it. This possibly also leads to changes in the DSL. 