### PR TITLE
Add schema validation for headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2020-04-01
+### Added
+- Headers validation
+
 ## [2.0.0] - 2019-11-19
 ### Changed
 - BREAKING: Required configuration of validation engine

--- a/lib/request_handler/base.rb
+++ b/lib/request_handler/base.rb
@@ -51,7 +51,7 @@ module RequestHandler
     end
 
     def headers
-      @headers ||= HeaderParser.new(env: request.env).run
+      @headers ||= parse_headers
     end
 
     def body_params
@@ -103,6 +103,21 @@ module RequestHandler
         allowed_options_type: config.lookup!("#{type}.allowed")
       ).run
       result.empty? ? defaults : result
+    end
+
+    def parse_headers
+      HeaderParser.new(header_parser_params).run
+    end
+
+    def header_parser_params
+      params = { env: request.env }
+
+      return params if config.nil?
+
+      params.merge(
+        schema:         config.lookup('headers.schema'),
+        schema_options: execute_options(config.lookup('headers.options'))
+      )
     end
 
     def parse_body_params

--- a/lib/request_handler/builder/headers_builder.rb
+++ b/lib/request_handler/builder/headers_builder.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'request_handler/builder/base'
+
+module RequestHandler
+  module Builder
+    class HeadersBuilder < Base
+      Headers = Struct.new(:schema, :options)
+
+      def create_klass_struct
+        @result = Headers.new
+      end
+
+      def schema(value)
+        @result.schema = value
+      end
+
+      def options(value)
+        @result.options = value
+      end
+    end
+  end
+end

--- a/lib/request_handler/builder/options_builder.rb
+++ b/lib/request_handler/builder/options_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'request_handler/builder/base'
+require 'request_handler/builder/headers_builder'
 require 'request_handler/builder/page_builder'
 require 'request_handler/builder/include_options_builder'
 require 'request_handler/builder/sort_options_builder'
@@ -14,7 +15,7 @@ module RequestHandler
   module Builder
     class OptionsBuilder < Base
       Options = Struct.new(:page, :include_options, :sort_options, :filter, :query, :body,
-                           :multipart, :fieldsets)
+                           :multipart, :fieldsets, :headers)
 
       def create_klass_struct
         @result = Options.new
@@ -52,6 +53,10 @@ module RequestHandler
         @result.fieldsets = build_fieldsets(&block)
       end
 
+      def headers(&block)
+        @result.headers = build_headers(&block)
+      end
+
       def build_page(&block)
         Docile.dsl_eval(PageBuilder.new, &block).build
       end
@@ -82,6 +87,10 @@ module RequestHandler
 
       def build_fieldsets(&block)
         Docile.dsl_eval(FieldsetsBuilder.new, &block).build
+      end
+
+      def build_headers(&block)
+        Docile.dsl_eval(HeadersBuilder.new, &block).build
       end
     end
   end

--- a/lib/request_handler/header_parser.rb
+++ b/lib/request_handler/header_parser.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'request_handler/schema_parser'
 require 'request_handler/error'
+
 module RequestHandler
-  class HeaderParser
-    def initialize(env:)
+  class HeaderParser < SchemaParser
+    def initialize(env:, schema: nil, schema_options: {})
+      super(schema: schema, schema_options: schema_options) unless schema.nil?
+
       raise MissingArgumentError, env: 'is missing' if env.nil?
       @headers = Helper.deep_transform_keys_in_object(env.select { |k, _v| k.start_with?('HTTP_') }) do |k|
         k[5..-1].downcase.to_sym
@@ -11,10 +15,34 @@ module RequestHandler
     end
 
     def run
-      headers
+      return headers if schema.nil?
+
+      validate_headers!
     end
 
     private
+
+    def validate_headers!
+      validate_schema(headers)
+    rescue SchemaValidationError => e
+      raise ExternalArgumentError, external_argument_error_params(e)
+    end
+
+    def external_argument_error_params(error)
+      error.errors.map do |schema_error|
+        header = schema_error[:source][:pointer]
+        {
+          status: '400',
+          code: "#{headers[header.to_sym] ? 'INVALID' : 'MISSING'}_HEADER",
+          detail: schema_error[:detail],
+          source: { header: format_header_name(header) }
+        }
+      end
+    end
+
+    def format_header_name(name)
+      name.split('_').map(&:capitalize).join('-')
+    end
 
     attr_reader :headers
   end

--- a/lib/request_handler/header_parser.rb
+++ b/lib/request_handler/header_parser.rb
@@ -34,8 +34,7 @@ module RequestHandler
         {
           status: '400',
           code: "#{headers[header.to_sym] ? 'INVALID' : 'MISSING'}_HEADER",
-          detail: schema_error[:detail],
-          source: { header: format_header_name(header) }
+          detail: "#{format_header_name(header)} #{schema_error[:detail]}"
         }
       end
     end

--- a/lib/request_handler/version.rb
+++ b/lib/request_handler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RequestHandler
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/spec/integration/header_parser_spec.rb
+++ b/spec/integration/header_parser_spec.rb
@@ -62,8 +62,7 @@ describe RequestHandler do
                 {
                   status: '400',
                   code: 'INVALID_HEADER',
-                  detail: 'must be an integer',
-                  source: { header: 'Client-Id' }
+                  detail: 'Client-Id must be an integer'
                 }
               ]
             )
@@ -81,8 +80,7 @@ describe RequestHandler do
                 {
                   status: '400',
                   code: 'MISSING_HEADER',
-                  detail: 'is missing',
-                  source: { header: 'Client-Id' }
+                  detail: 'Client-Id is missing'
                 }
               ]
             )

--- a/spec/integration/header_parser_spec.rb
+++ b/spec/integration/header_parser_spec.rb
@@ -39,7 +39,7 @@ describe RequestHandler do
           options do
             headers do
               schema(Dry::Schema.Params do
-                required(:client_id).filled(:string)
+                required(:client_id).filled(:integer)
               end)
             end
           end
@@ -53,7 +53,7 @@ describe RequestHandler do
       end
 
       context 'when the headers are invalid' do
-        let(:headers) { { 'HTTP_CLIENT_ID' => 123 } }
+        let(:headers) { { 'HTTP_CLIENT_ID' => 'abc' } }
 
         it 'raises an exception' do
           expect { to_dto }.to raise_error(RequestHandler::ExternalArgumentError) do |raised_error|
@@ -62,7 +62,7 @@ describe RequestHandler do
                 {
                   status: '400',
                   code: 'INVALID_HEADER',
-                  detail: 'must be a string',
+                  detail: 'must be an integer',
                   source: { header: 'Client-Id' }
                 }
               ]
@@ -91,11 +91,14 @@ describe RequestHandler do
       end
 
       context 'when the headers are valid' do
-        let(:client_id) { 'foo.123' }
-        let(:headers) { { 'HTTP_CLIENT_ID' => client_id } }
+        let(:headers) { { 'HTTP_CLIENT_ID' => '0001234' } }
 
         it 'does not raise an exception' do
-          expect(to_dto).to eq(OpenStruct.new(headers: { client_id: client_id }))
+          expect { to_dto }.to_not raise_error(RequestHandler::ExternalArgumentError)
+        end
+
+        it 'sets the headers' do
+          expect(to_dto).to eq(OpenStruct.new(headers: { client_id: 1234 }))
         end
       end
     end

--- a/spec/integration/header_parser_spec.rb
+++ b/spec/integration/header_parser_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 describe RequestHandler do
-  shared_examples 'it set the headers' do
+  shared_examples 'it sets the headers' do
     subject(:to_dto) { class_without_headers_schema.new(request: request).to_dto }
     let(:request) { build_mock_request(params: {}, headers: headers, body: '') }
 
@@ -103,14 +103,14 @@ describe RequestHandler do
 
   context 'with dry engine' do
     include_context 'with dry validation engine' do
-      it_behaves_like 'it set the headers'
+      it_behaves_like 'it sets the headers'
       it_behaves_like 'it validates the headers'
     end
   end
 
   context 'with definition engine' do
     include_context 'with definition validation engine' do
-      it_behaves_like 'it set the headers'
+      it_behaves_like 'it sets the headers'
       it_behaves_like 'it validates the headers'
     end
   end

--- a/spec/integration/header_parser_spec.rb
+++ b/spec/integration/header_parser_spec.rb
@@ -2,11 +2,12 @@
 
 require 'spec_helper'
 describe RequestHandler do
-  shared_examples 'it validates headers' do
-    subject(:to_dto) { testclass.new(request: request).to_dto }
+  shared_examples 'it set the headers' do
+    subject(:to_dto) { class_without_headers_schema.new(request: request).to_dto }
     let(:request) { build_mock_request(params: {}, headers: headers, body: '') }
+
     context 'HeaderParser' do
-      let(:testclass) do
+      let(:class_without_headers_schema) do
         Class.new(RequestHandler::Base) do
           def to_dto
             OpenStruct.new(
@@ -15,10 +16,12 @@ describe RequestHandler do
           end
         end
       end
+
       context 'without headers' do
         let(:headers) { nil }
         it { expect { to_dto }.to raise_error(RequestHandler::MissingArgumentError) }
       end
+
       context 'with headers set correctly' do
         let(:headers) { { 'HTTP_APP_KEY' => 'some.app.key', 'HTTP_USER_ID' => '345' } }
         it { expect(to_dto).to eq(OpenStruct.new(headers: { app_key: 'some.app.key', user_id: '345' })) }
@@ -26,15 +29,89 @@ describe RequestHandler do
     end
   end
 
+  shared_examples 'it validates the headers' do
+    subject(:to_dto) { class_with_headers_schema.new(request: request).to_dto }
+    let(:request) { build_mock_request(params: {}, headers: headers, body: '') }
+
+    context 'HeaderParser' do
+      let(:class_with_headers_schema) do
+        Class.new(RequestHandler::Base) do
+          options do
+            headers do
+              schema(Dry::Schema.Params do
+                required(:client_id).filled(:string)
+              end)
+            end
+          end
+
+          def to_dto
+            OpenStruct.new(
+              headers: headers
+            )
+          end
+        end
+      end
+
+      context 'when the headers are invalid' do
+        let(:headers) { { 'HTTP_CLIENT_ID' => 123 } }
+
+        it 'raises an exception' do
+          expect { to_dto }.to raise_error(RequestHandler::ExternalArgumentError) do |raised_error|
+            expect(raised_error.errors).to eq(
+              [
+                {
+                  status: '400',
+                  code: 'INVALID_HEADER',
+                  detail: 'must be a string',
+                  source: { header: 'Client-Id' }
+                }
+              ]
+            )
+          end
+        end
+      end
+
+      context 'when the headers are missing' do
+        let(:headers) { {} }
+
+        it 'raises an exception' do
+          expect { to_dto }.to raise_error(RequestHandler::ExternalArgumentError) do |raised_error|
+            expect(raised_error.errors).to eq(
+              [
+                {
+                  status: '400',
+                  code: 'MISSING_HEADER',
+                  detail: 'is missing',
+                  source: { header: 'Client-Id' }
+                }
+              ]
+            )
+          end
+        end
+      end
+
+      context 'when the headers are valid' do
+        let(:client_id) { 'foo.123' }
+        let(:headers) { { 'HTTP_CLIENT_ID' => client_id } }
+
+        it 'does not raise an exception' do
+          expect(to_dto).to eq(OpenStruct.new(headers: { client_id: client_id }))
+        end
+      end
+    end
+  end
+
   context 'with dry engine' do
     include_context 'with dry validation engine' do
-      it_behaves_like 'it validates headers'
+      it_behaves_like 'it set the headers'
+      it_behaves_like 'it validates the headers'
     end
   end
 
   context 'with definition engine' do
     include_context 'with definition validation engine' do
-      it_behaves_like 'it validates headers'
+      it_behaves_like 'it set the headers'
+      it_behaves_like 'it validates the headers'
     end
   end
 end

--- a/spec/request_handler/header_parser_spec.rb
+++ b/spec/request_handler/header_parser_spec.rb
@@ -36,8 +36,7 @@ describe RequestHandler::HeaderParser do
                 {
                   status: '400',
                   code: 'MISSING_HEADER',
-                  detail: 'is missing',
-                  source: { header: 'Client-Id' }
+                  detail: 'Client-Id is missing'
                 }
               ]
             )
@@ -54,8 +53,7 @@ describe RequestHandler::HeaderParser do
                 {
                   status: '400',
                   code: 'INVALID_HEADER',
-                  detail: 'must be an integer',
-                  source: { header: 'Client-Id' }
+                  detail: 'Client-Id must be an integer'
                 }
               ]
             )

--- a/spec/request_handler/header_parser_spec.rb
+++ b/spec/request_handler/header_parser_spec.rb
@@ -79,7 +79,7 @@ describe RequestHandler::HeaderParser do
       it_behaves_like 'fetch proper headers'
     end
 
-    context 'converts the heades into lowercase without the http_ prefix' do
+    context 'converts the headers into lowercase without the http_ prefix' do
       let(:headers) do
         {
           'HTTP_USER_ID'     => 'user1',

--- a/spec/request_handler/header_parser_spec.rb
+++ b/spec/request_handler/header_parser_spec.rb
@@ -17,13 +17,13 @@ describe RequestHandler::HeaderParser do
     end
 
     context 'when the header `Client-Id` is defined in schema' do
-      let(:headers) { { 'HTTP_CLIENT_ID' => 'foo' } }
+      let(:headers) { { 'HTTP_CLIENT_ID' => '0001234' } }
       let(:schema) do
         Dry::Schema.Params do
-          required(:client_id).filled(:string)
+          required(:client_id).filled(:integer)
         end
       end
-      let(:expected_headers) { { client_id: 'foo' } }
+      let(:expected_headers) { { client_id: 1234 } }
 
       it_behaves_like 'fetch proper headers'
 
@@ -46,7 +46,7 @@ describe RequestHandler::HeaderParser do
       end
 
       context 'when the header `Client-Id` is invalid' do
-        let(:headers) { { 'HTTP_CLIENT_ID' => 123 } }
+        let(:headers) { { 'HTTP_CLIENT_ID' => 'abc' } }
         it 'returns code INVALID_HEADER' do
           expect { subject }.to raise_error(RequestHandler::ExternalArgumentError) do |raised_error|
             expect(raised_error.errors).to eq(
@@ -54,7 +54,7 @@ describe RequestHandler::HeaderParser do
                 {
                   status: '400',
                   code: 'INVALID_HEADER',
-                  detail: 'must be a string',
+                  detail: 'must be an integer',
                   source: { header: 'Client-Id' }
                 }
               ]


### PR DESCRIPTION
I had to implement headers validation in some services and then I decided to add a proper schema validation for headers directly to the gem.

The `headers` block is not required to keep backward compatibility.