### PR TITLE
Handle parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `ParseError` error type
+
+### Changed
+- Rescue and translate `MultiJson::ParseError` while parsing body
+
 ## [2.1.0] - 2020-04-01
 ### Added
 - Headers validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ParseError` error type
+- `INVALID_BODY_FORMAT` JSON:API error
 
 ### Changed
 - Rescue and translate `MultiJson::ParseError` while parsing body

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ with one issue per line.
 | `:code`                   | `:status` | What is it? |
 |:--------------------------|:----------|:------------|
 | INVALID_RESOURCE_SCHEMA   | 422       | Resource did not pass configured validation |
+| INVALID_BODY_FORMAT       | 400       | Request body is invalid JSON |
 | INVALID_QUERY_PARAMETER   | 400       | Query parameter violates syntax or did not pass configured validation |
 | MISSING_QUERY_PARAMETER   | 400       | Query parameter required in configuration is missing |
 | INVALID_JSON_API          | 400       | Request body violates JSON:API syntax |

--- a/lib/request_handler/body_parser.rb
+++ b/lib/request_handler/body_parser.rb
@@ -31,7 +31,9 @@ module RequestHandler
       b = b.read
       b.empty? ? {} : MultiJson.load(b)
     rescue MultiJson::ParseError => e
-      raise ParseError, json: e.message
+      raise BodyFormatError, [{ status: '400',
+                                code: 'INVALID_BODY_FORMAT',
+                                detail: e.message }]
     end
 
     attr_reader :request, :schema, :schema_options, :type

--- a/lib/request_handler/body_parser.rb
+++ b/lib/request_handler/body_parser.rb
@@ -30,6 +30,8 @@ module RequestHandler
       b.rewind
       b = b.read
       b.empty? ? {} : MultiJson.load(b)
+    rescue MultiJson::ParseError => e
+      raise ParseError, json: e.message
     end
 
     attr_reader :request, :schema, :schema_options, :type

--- a/lib/request_handler/error.rb
+++ b/lib/request_handler/error.rb
@@ -29,8 +29,6 @@ module RequestHandler
       RequestHandler.configuration.raise_jsonapi_errors ? @errors : []
     end
   end
-  class ParseError < ExternalBaseError
-  end
   class MissingArgumentError < InternalBaseError
   end
   class ExternalArgumentError < JsonApiError
@@ -44,6 +42,8 @@ module RequestHandler
   class NoConfigAvailableError < InternalBaseError
   end
 
+  class BodyFormatError < ExternalArgumentError
+  end
   class BodyParamsError < ExternalArgumentError
   end
   class FieldsetsParamsError < ExternalArgumentError

--- a/lib/request_handler/error.rb
+++ b/lib/request_handler/error.rb
@@ -29,6 +29,8 @@ module RequestHandler
       RequestHandler.configuration.raise_jsonapi_errors ? @errors : []
     end
   end
+  class ParseError < ExternalBaseError
+  end
   class MissingArgumentError < InternalBaseError
   end
   class ExternalArgumentError < JsonApiError

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -114,7 +114,7 @@ describe RequestHandler::BodyParser do
                                    body: StringIO.new('foo'))
         ).run
       end
-        .to raise_error(RequestHandler::ParseError)
+        .to raise_error(RequestHandler::BodyFormatError)
     end
 
     it "doesn't fail if the request body does not contain a data hash" do

--- a/spec/request_handler/body_parser_spec.rb
+++ b/spec/request_handler/body_parser_spec.rb
@@ -103,6 +103,20 @@ describe RequestHandler::BodyParser do
         .to raise_error(RequestHandler::MissingArgumentError)
     end
 
+    it 'fails if the request body is not json' do
+      schema = Dry::Schema.JSON {}
+      expect do
+        described_class.new(
+          schema: schema,
+          type: type,
+          request: instance_double('Rack::Request',
+                                   params: {},
+                                   body: StringIO.new('foo'))
+        ).run
+      end
+        .to raise_error(RequestHandler::ParseError)
+    end
+
     it "doesn't fail if the request body does not contain a data hash" do
       schema = Dry::Schema.JSON {}
       expect do


### PR DESCRIPTION
Requests where the body is not valid JSON would cause `MultiJson::ParseError` to be raised but not translated to a `RequestHandler` error. Handling `RequestHandler::ExternalBaseError` should arguably include parsing errors caused by invalid user input.