### PR TITLE
Rename error source's param to parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Error obejct's source attribute `param` to `parameters`
+
 ## [2.1.0] - 2020-04-01
 ### Added
 - Headers validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Error object's source attribute from `param` to `parameters`
+- Change error object's source attribute from `param` to `parameters`
 
 ## [2.1.0] - 2020-04-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Error obejct's source attribute `param` to `parameters`
+- Error object's source attribute from `param` to `parameters`
 
 ## [2.1.0] - 2020-04-01
 ### Added

--- a/lib/request_handler/fieldsets_parser.rb
+++ b/lib/request_handler/fieldsets_parser.rb
@@ -46,7 +46,7 @@ module RequestHandler
       raise FieldsetsParamsError, [{ code: 'INVALID_QUERY_PARAMETER',
                                      status: '400',
                                      detail: "allowed fieldset does not include '#{option}'",
-                                     source: { param: "fields[#{type}]" } }]
+                                     source: { parameter: "fields[#{type}]" } }]
     end
 
     def check_required_fieldsets_types(fieldsets)
@@ -62,7 +62,7 @@ module RequestHandler
           code: 'INVALID_QUERY_PARAMETER',
           status: '400',
           detail: "fieldset for '#{type}' not allowed",
-          source: { param: "fields[#{type}]" }
+          source: { parameter: "fields[#{type}]" }
         }
       ]
     end
@@ -77,7 +77,7 @@ module RequestHandler
         {
           code: 'MISSING_QUERY_PARAMETER',
           status: '400',
-          source: { param: '' },
+          source: { parameter: '' },
           detail: "missing required parameter fields[#{type}]"
         }
       end

--- a/lib/request_handler/filter_parser.rb
+++ b/lib/request_handler/filter_parser.rb
@@ -37,7 +37,7 @@ module RequestHandler
       {
         status: '400',
         code: 'INVALID_QUERY_PARAMETER',
-        source: { param: source_param }
+        source: { parameter: source_param }
       }
     end
 

--- a/lib/request_handler/include_option_parser.rb
+++ b/lib/request_handler/include_option_parser.rb
@@ -35,7 +35,7 @@ module RequestHandler
           status: '400',
           code:   code,
           detail: detail,
-          source: { param: 'include' }
+          source: { parameter: 'include' }
         }
       ]
     end

--- a/lib/request_handler/page_parser.rb
+++ b/lib/request_handler/page_parser.rb
@@ -79,7 +79,7 @@ module RequestHandler
         code: 'INVALID_QUERY_PARAMETER',
         status: '400',
         detail: 'must be a positive integer',
-        source: { param: "page[#{param}]" }
+        source: { parameter: "page[#{param}]" }
       }]
     end
 

--- a/lib/request_handler/query_parser.rb
+++ b/lib/request_handler/query_parser.rb
@@ -20,7 +20,7 @@ module RequestHandler
         { status: '400',
           code: "#{query[param] ? 'INVALID' : 'MISSING'}_QUERY_PARAMETER",
           detail: schema_error[:detail],
-          source: { param: param } }
+          source: { parameter: param } }
       end)
     end
 

--- a/lib/request_handler/sort_option_parser.rb
+++ b/lib/request_handler/sort_option_parser.rb
@@ -51,7 +51,7 @@ module RequestHandler
       {
         code: 'INVALID_QUERY_PARAMETER',
         status: '400',
-        source: { param: 'sort' },
+        source: { parameter: 'sort' },
         detail: detail
       }
     end

--- a/spec/integration/fieldsets_parser_spec.rb
+++ b/spec/integration/fieldsets_parser_spec.rb
@@ -41,7 +41,7 @@ describe RequestHandler do
             jsonapi_error = { code: 'INVALID_QUERY_PARAMETER',
                               status: '400',
                               detail: "fieldset for 'photos' not allowed",
-                              source: { param: 'fields[photos]' } }
+                              source: { parameter: 'fields[photos]' } }
             expect(raised_error.errors).to match_array([jsonapi_error])
           end
         end

--- a/spec/integration/schema_parser_spec.rb
+++ b/spec/integration/schema_parser_spec.rb
@@ -215,7 +215,7 @@ describe RequestHandler do
                                                              status: '400',
                                                              code: 'INVALID_QUERY_PARAMETER',
                                                              detail: anything,
-                                                             source: { param: 'filter[name]' }
+                                                             source: { parameter: 'filter[name]' }
                                                            }])
               end
             end

--- a/spec/request_handler/fieldsets_parser_spec.rb
+++ b/spec/request_handler/fieldsets_parser_spec.rb
@@ -88,7 +88,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "allowed fieldset does not include 'good'",
-            source: { param: 'fields[posts]' }
+            source: { parameter: 'fields[posts]' }
           }
         end
         let(:params) { { 'fields' => { 'posts' => 'awesome,good' } } }
@@ -111,7 +111,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "allowed fieldset does not include 'post1'",
-            source: { param: 'fields[posts]' }
+            source: { parameter: 'fields[posts]' }
           }
         end
         let(:params) { { 'fields' => { 'posts' => 'post1,post2', 'videos' => 'nr1,nr2' } } }
@@ -129,7 +129,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "fieldset for 'musicfiles' not allowed",
-            source: { param: 'fields[musicfiles]' }
+            source: { parameter: 'fields[musicfiles]' }
           }
         end
         let(:error) { RequestHandler::OptionNotAllowedError }
@@ -146,7 +146,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "fieldset for 'games' not allowed",
-            source: { param: 'fields[games]' }
+            source: { parameter: 'fields[games]' }
           }
         end
         let(:error) { RequestHandler::OptionNotAllowedError }
@@ -162,7 +162,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'MISSING_QUERY_PARAMETER',
             status: '400',
             detail: 'missing required parameter fields[posts]',
-            source: { param: '' }
+            source: { parameter: '' }
           }
         end
         let(:params) { { 'fields' => { 'photos' => 'bar' } } }
@@ -178,7 +178,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'MISSING_QUERY_PARAMETER',
             status: '400',
             detail: 'missing required parameter fields[posts]',
-            source: { param: '' }
+            source: { parameter: '' }
           }
         end
         let(:params) { { 'fields' => { 'photos' => 'bar' } } }
@@ -191,7 +191,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'MISSING_QUERY_PARAMETER',
             status: '400',
             detail: 'missing required parameter fields[posts]',
-            source: { param: '' }
+            source: { parameter: '' }
           }
         end
         let(:params) { {} }
@@ -205,7 +205,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "fieldset for 'post' not allowed",
-            source: { param: 'fields[post]' }
+            source: { parameter: 'fields[post]' }
           }
         end
         let(:error) { RequestHandler::OptionNotAllowedError }
@@ -218,7 +218,7 @@ describe RequestHandler::FieldsetsParser do
             code: 'INVALID_QUERY_PARAMETER',
             status: '400',
             detail: "allowed fieldset does not include 'bars'",
-            source: { param: 'fields[posts]' }
+            source: { parameter: 'fields[posts]' }
           }
         end
         let(:params) { { 'fields' => { 'posts' => 'bars' } } }

--- a/spec/request_handler/filter_parser_spec.rb
+++ b/spec/request_handler/filter_parser_spec.rb
@@ -117,7 +117,7 @@ describe RequestHandler::FilterParser do
         jsonapi_error = {
           status: '400',
           code: 'INVALID_QUERY_PARAMETER',
-          source: { param: 'filter' },
+          source: { parameter: 'filter' },
           detail: 'Filter parameter must conform to JSON API recommendation',
           links: { about: anything }
         }

--- a/spec/request_handler/page_parser_spec.rb
+++ b/spec/request_handler/page_parser_spec.rb
@@ -122,7 +122,7 @@ describe RequestHandler::PageParser do
         code: 'INVALID_QUERY_PARAMETER',
         status: '400',
         detail: 'must be a positive integer',
-        source: { param: expected_param }
+        source: { parameter: expected_param }
       }
     end
 

--- a/spec/request_handler/query_parser_spec.rb
+++ b/spec/request_handler/query_parser_spec.rb
@@ -33,7 +33,7 @@ describe RequestHandler::QueryParser do
                                                        status: '400',
                                                        code: 'MISSING_QUERY_PARAMETER',
                                                        detail: 'is missing',
-                                                       source: { param: 'name' }
+                                                       source: { parameter: 'name' }
                                                      }])
         end
       end

--- a/spec/request_handler/schema_parser_spec.rb
+++ b/spec/request_handler/schema_parser_spec.rb
@@ -26,7 +26,7 @@ describe RequestHandler::SchemaParser do
 
   module Types
     require 'dry-types'
-    include Dry::Types.module
+    include Dry::Types()
     ArrayFromCSV = Strict::Array.constructor do |val|
       val.is_a?(::Array) ? val : val.to_s.split(',')
     end

--- a/spec/request_handler/sort_option_parser_spec.rb
+++ b/spec/request_handler/sort_option_parser_spec.rb
@@ -56,7 +56,7 @@ describe RequestHandler::SortOptionParser do
       code: 'INVALID_QUERY_PARAMETER',
       status: '400',
       detail: expected_detail,
-      source: { param: 'sort' }
+      source: { parameter: 'sort' }
     }
   end
 


### PR DESCRIPTION
The current implementation of the error's source object contains a `param` attribute, pointing to invalid URI query parameters.
According to the [json:api spec](https://jsonapi.org/format/#error-objects), this attribute should be renamed to `parameters`.